### PR TITLE
Derived classes must call the base class method geometryChanged() within...

### DIFF
--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -107,10 +107,11 @@ void QuickMozView::itemChange(ItemChange change, const ItemChangeData &)
     }
 }
 
-void QuickMozView::geometryChanged(const QRectF & newGeometry, const QRectF&)
+void QuickMozView::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
 {
     d->mSize = newGeometry.size().toSize();
     d->UpdateViewSize();
+    QQuickItem::geometryChanged(newGeometry, oldGeometry);
 }
 
 void QuickMozView::sceneGraphInitialized()


### PR DESCRIPTION
... their implementation

See https://qt-project.org/doc/qt-5.1/qtquick/qquickitem.html#geometryChanged for details.
