### PR TITLE
[qtmozembed] Expose contentWidth and contentHeight to qml

### DIFF
--- a/rpm/qtmozembed-qt5.spec
+++ b/rpm/qtmozembed-qt5.spec
@@ -1,6 +1,6 @@
 Name:       qtmozembed-qt5
 Summary:    Qt embeddings for Gecko
-Version:    1.5.8
+Version:    1.5.11
 Release:    1
 Group:      Applications/Internet
 License:    Mozilla License

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -70,6 +70,8 @@ public:
     virtual void SetIsFocused(bool aIsFocused);
     virtual void CompositorCreated();
 
+    void UpdateContentSize(unsigned int aWidth, unsigned int aHeight);
+
     IMozQViewIface* mViewIface;
     QMozContext* mContext;
     mozilla::embedlite::EmbedLiteView* mView;

--- a/src/qmozcontext.cpp
+++ b/src/qmozcontext.cpp
@@ -42,6 +42,7 @@ public:
     : q(qq)
     , mApp(NULL)
     , mInitialized(false)
+    , mPixelRatio(1.0)
     , mThread(new QThread())
     , mEmbedStarted(false)
     , mQtPump(NULL)
@@ -181,6 +182,7 @@ private:
     QMozContext* q;
     EmbedLiteApp* mApp;
     bool mInitialized;
+    float mPixelRatio;
     friend class QMozContext;
     QThread* mThread;
     bool mEmbedStarted;
@@ -307,6 +309,17 @@ EmbedLiteApp*
 QMozContext::GetApp()
 {
     return d->mApp;
+}
+
+void QMozContext::setPixelRatio(float ratio)
+{
+    d->mPixelRatio = ratio;
+    setPref(QString("layout.css.devPixelsPerPx"), QString("%1").arg(ratio));
+}
+
+float QMozContext::pixelRatio() const
+{
+    return d->mPixelRatio;
 }
 
 void QMozContext::stopEmbedding()

--- a/src/qmozcontext.h
+++ b/src/qmozcontext.h
@@ -43,6 +43,8 @@ public:
     virtual ~QMozContext();
 
     mozilla::embedlite::EmbedLiteApp* GetApp();
+    void setPixelRatio(float ratio);
+    float pixelRatio() const;
 
     static QMozContext* GetInstance();
 

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -46,6 +46,8 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     Q_PROPERTY(int loadProgress READ loadProgress NOTIFY loadProgressChanged) \
     Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged FINAL) \
     Q_PROPERTY(QRectF contentRect READ contentRect NOTIFY viewAreaChanged FINAL) \
+    Q_PROPERTY(qreal contentWidth READ contentWidth NOTIFY contentWidthChanged FINAL) \
+    Q_PROPERTY(qreal contentHeight READ contentHeight NOTIFY contentHeightChanged FINAL) \
     Q_PROPERTY(QSizeF scrollableSize READ scrollableSize FINAL) \
     Q_PROPERTY(QPointF scrollableOffset READ scrollableOffset NOTIFY scrollableOffsetChanged FINAL) \
     Q_PROPERTY(float resolution READ resolution) \
@@ -63,6 +65,8 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     bool canGoForward() const; \
     bool loading() const; \
     QRectF contentRect() const; \
+    qreal contentWidth() const; \
+    qreal contentHeight() const; \
     QSizeF scrollableSize() const; \
     QPointF scrollableOffset() const; \
     float resolution() const; \
@@ -122,6 +126,8 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void imeNotification(int state, bool open, int cause, int focusChange, const QString& type); \
     void bgColorChanged(); \
     void useQmlMouse(bool value); \
-    void draggingChanged();
+    void draggingChanged(); \
+    void contentWidthChanged(); \
+    void contentHeightChanged();
 
 #endif /* qmozview_defined_wrapper_h */

--- a/src/qmozview_templated_wrapper.h
+++ b/src/qmozview_templated_wrapper.h
@@ -34,6 +34,8 @@ public:
     virtual void securityChanged(QString status, uint state) = 0;
     virtual void firstPaint(int offx, int offy) = 0;
     virtual void contentLoaded(QString docuri) = 0;
+    virtual void contentWidthChanged() = 0;
+    virtual void contentHeightChanged() = 0;
     virtual void viewAreaChanged() = 0;
     virtual void scrollableOffsetChanged() = 0;
     virtual void handleLongTap(QPoint point, QMozReturnValue* retval) = 0;
@@ -161,6 +163,16 @@ public:
     void draggingChanged()
     {
         Q_EMIT view.draggingChanged();
+    }
+
+    void contentWidthChanged()
+    {
+        Q_EMIT view.contentWidthChanged();
+    }
+
+    void contentHeightChanged()
+    {
+        Q_EMIT view.contentHeightChanged();
     }
 
     TMozQView& view;

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -420,7 +420,7 @@ QPointF QuickMozView::scrollableOffset() const
 
 float QuickMozView::resolution() const
 {
-    return d->mContentResolution;
+    return d->mContext->pixelRatio();
 }
 
 bool QuickMozView::isPainted() const
@@ -447,6 +447,17 @@ bool QuickMozView::dragging() const
 {
     return d->mDragging;
 }
+
+qreal QuickMozView::contentWidth() const
+{
+    return d->mScrollableSize.width();
+}
+
+qreal QuickMozView::contentHeight() const
+{
+    return d->mScrollableSize.height();
+}
+
 
 void QuickMozView::loadHtml(const QString& html, const QUrl& baseUrl)
 {


### PR DESCRIPTION
Values of contentWidth and contentHeight are scaled to qml, not in css pixels.
