### PR TITLE
[qtmozembed] Disable flicking if touch point is not moved

### DIFF
--- a/rpm/qtmozembed-qt5.spec
+++ b/rpm/qtmozembed-qt5.spec
@@ -1,6 +1,6 @@
 Name:       qtmozembed-qt5
 Summary:    Qt embeddings for Gecko
-Version:    1.5.11
+Version:    1.5.13
 Release:    1
 Group:      Applications/Internet
 License:    Mozilla License

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -71,6 +71,7 @@ public:
     virtual void CompositorCreated();
 
     void UpdateContentSize(unsigned int aWidth, unsigned int aHeight);
+    void TestFlickingMode(QTouchEvent *event);
 
     IMozQViewIface* mViewIface;
     QMozContext* mContext;
@@ -82,6 +83,12 @@ public:
     QSGTexture* mTempTexture;
 #endif
     QSize mSize;
+    qint64 mLastTimestamp;
+    qint64 mElapsedTouchTime;
+    qint64 mLastStationaryTimestamp;
+    QPointF mLastPos;
+    QPointF mLastStationaryPos;
+    bool mCanFlick;
     QTime mTouchTime;
     bool mPendingTouchEvent;
     QTime mPanningTime;


### PR DESCRIPTION
If finger stays 200ms or more in one position, flicking is
not allowed.

In addition, this commit adds touch press area and pressure for
instantiated mozilla::SingleTouchData objects. Also mozilla::MultiTouchInput
end has timestamp of the last touch update.
