### PR TITLE
[qtmozembed] Add vertical and horizontal scroll decorators to C++.

### DIFF
--- a/qmlplugin5/main.cpp
+++ b/qmlplugin5/main.cpp
@@ -8,6 +8,8 @@
 #include <QtQml/qqml.h>
 #include "quickmozview.h"
 #include "qmozcontext.h"
+#include "qmozhorizontalscrolldecorator.h"
+#include "qmozverticalscrolldecorator.h"
 #include "qmlmozcontext.h"
 
 class QtMozEmbedPlugin : public QQmlExtensionPlugin
@@ -21,6 +23,8 @@ public:
         Q_ASSERT(uri == QLatin1String("Qt5Mozilla"));
         qmlRegisterType<QuickMozView>("Qt5Mozilla", 1, 0, "QmlMozView");
         qmlRegisterType<QmlMozContext>("Qt5Mozilla", 1, 0, "QmlMozContext");
+        qmlRegisterUncreatableType<QMozVerticalScrollDecorator>("Qt5Mozilla", 1, 0, "QmlMozVerticalScrollDecorator", "");
+        qmlRegisterUncreatableType<QMozHorizontalScrollDecorator>("Qt5Mozilla", 1, 0, "QmlMozHorizontalScrollDecorator", "");
         setenv("EMBED_COMPONENTS_PATH", DEFAULT_COMPONENTS_PATH, 1);
     }
 };

--- a/src/qgraphicsmozview.cpp
+++ b/src/qgraphicsmozview.cpp
@@ -191,7 +191,7 @@ void QGraphicsMozView::setGeometry(const QRectF& rect)
 
     // NOTE: call geometry() as setGeometry ensures that
     // the geometry is within legal bounds (minimumSize, maximumSize)
-    d->mSize = geometry().size().toSize();
+    d->mSize = geometry().size();
     Q_EMIT requestGLContext(d->mHasContext, d->mGLSurfaceSize);
     d->UpdateViewSize();
 }

--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -39,6 +39,7 @@ QGraphicsMozViewPrivate::QGraphicsMozViewPrivate(IMozQViewIface* aViewIface)
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
     , mTempTexture(NULL)
 #endif
+    , mEnabled(true)
     , mLastTimestamp(0)
     , mElapsedTouchTime(0)
     , mLastStationaryTimestamp(0)
@@ -456,6 +457,22 @@ bool QGraphicsMozViewPrivate::ScrollUpdate(const gfxPoint& aPosition, const floa
         mScrollableOffset.setX(aPosition.x * mContentResolution);
         mScrollableOffset.setY(aPosition.y * mContentResolution);
         mViewIface->scrollableOffsetChanged();
+
+        if (mEnabled) {
+            // Update vertical scroll decorator
+            qreal ySizeRatio = mContentRect.height() / mScrollableSize.height();
+            qreal tmpValue = mSize.height() * ySizeRatio;
+            mVerticalScrollDecorator.setHeight(tmpValue);
+            tmpValue = mScrollableOffset.y() * ySizeRatio;
+            mVerticalScrollDecorator.setY(tmpValue);
+
+            // Update horizontal scroll decorator
+            qreal xSizeRatio = mContentRect.width() / mScrollableSize.width();
+            tmpValue = mSize.width() * xSizeRatio;
+            mHorizontalScrollDecorator.setWidth(tmpValue);
+            tmpValue = mScrollableOffset.x() * xSizeRatio;
+            mHorizontalScrollDecorator.setX(tmpValue);
+        }
     }
 
     return false;

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -16,6 +16,8 @@
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include <QSGSimpleTextureNode>
 #endif
+#include "qmozhorizontalscrolldecorator.h"
+#include "qmozverticalscrolldecorator.h"
 #include "mozilla/embedlite/EmbedLiteView.h"
 #include "qmozview_templated_wrapper.h"
 #include "qmozview_defined_wrapper.h"
@@ -82,7 +84,8 @@ public:
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
     QSGTexture* mTempTexture;
 #endif
-    QSize mSize;
+    bool mEnabled;
+    QSizeF mSize;
     qint64 mLastTimestamp;
     qint64 mElapsedTouchTime;
     qint64 mLastStationaryTimestamp;
@@ -104,6 +107,9 @@ public:
     QRectF mContentRect;
     QSizeF mScrollableSize;
     QPointF mScrollableOffset;
+    // Non visual
+    QMozVerticalScrollDecorator mVerticalScrollDecorator;
+    QMozHorizontalScrollDecorator mHorizontalScrollDecorator;
     float mContentResolution;
     bool mIsPainted;
     Qt::InputMethodHints mInputMethodHints;

--- a/src/qmozhorizontalscrolldecorator.cpp
+++ b/src/qmozhorizontalscrolldecorator.cpp
@@ -1,0 +1,52 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QtGlobal>
+#include "qmozhorizontalscrolldecorator.h"
+
+QMozHorizontalScrollDecorator::QMozHorizontalScrollDecorator(QObject *parent)
+    : QObject(parent)
+    , mX(0.0)
+    , mWidth(0.0)
+{
+}
+
+QMozHorizontalScrollDecorator::~QMozHorizontalScrollDecorator()
+{
+}
+
+qreal QMozHorizontalScrollDecorator::x() const
+{
+    return mX;
+}
+
+void QMozHorizontalScrollDecorator::setX(qreal x)
+{
+    if (qIsNull(x))
+        return;
+
+    if (x != mX) {
+        mX = x;
+        Q_EMIT xChanged();
+    }
+}
+
+qreal QMozHorizontalScrollDecorator::width() const
+{
+    return mWidth;
+}
+
+void QMozHorizontalScrollDecorator::setWidth(qreal width)
+{
+    if (qIsNull(width))
+        return;
+
+    // Fuzzy compare?, maybe worth checking against small threshold.
+    if (width != mWidth) {
+        mWidth = width;
+        Q_EMIT widthChanged();
+    }
+}
+

--- a/src/qmozhorizontalscrolldecorator.h
+++ b/src/qmozhorizontalscrolldecorator.h
@@ -1,0 +1,36 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef QMOZHORIZONTALSCROLLDECORATOR_H
+#define QMOZHORIZONTALSCROLLDECORATOR_H
+
+#include <QObject>
+
+class QMozHorizontalScrollDecorator : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal x READ x NOTIFY xChanged FINAL)
+    Q_PROPERTY(qreal width READ width NOTIFY widthChanged FINAL)
+
+public:
+    QMozHorizontalScrollDecorator(QObject *parent = 0);
+    virtual ~QMozHorizontalScrollDecorator();
+
+    qreal x() const;
+    void setX(qreal x);
+
+    qreal width() const;
+    void setWidth(qreal width);
+
+Q_SIGNALS:
+    void xChanged();
+    void widthChanged();
+
+private:
+    qreal mX;
+    qreal mWidth;
+};
+
+#endif

--- a/src/qmozverticalscrolldecorator.cpp
+++ b/src/qmozverticalscrolldecorator.cpp
@@ -1,0 +1,51 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QtGlobal>
+#include "qmozverticalscrolldecorator.h"
+
+QMozVerticalScrollDecorator::QMozVerticalScrollDecorator(QObject *parent)
+    : QObject(parent)
+    , mY(0.0)
+    , mHeight(0.0)
+{
+}
+
+QMozVerticalScrollDecorator::~QMozVerticalScrollDecorator()
+{
+}
+
+qreal QMozVerticalScrollDecorator::y() const
+{
+    return mY;
+}
+
+void QMozVerticalScrollDecorator::setY(qreal y)
+{
+    if (qIsNull(y))
+        return;
+
+    if (y != mY) {
+        mY = y;
+        Q_EMIT yChanged();
+    }
+}
+
+qreal QMozVerticalScrollDecorator::height() const
+{
+    return mHeight;
+}
+
+void QMozVerticalScrollDecorator::setHeight(qreal height)
+{
+    if (qIsNull(height))
+        return;
+
+    // Fuzzy compare?, maybe worth checking against small threshold.
+    if (height != mHeight) {
+        mHeight = height;
+        Q_EMIT heightChanged();
+    }
+}

--- a/src/qmozverticalscrolldecorator.h
+++ b/src/qmozverticalscrolldecorator.h
@@ -1,0 +1,36 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef QMOZVERTICALSCROLLDECORATOR_H
+#define QMOZVERTICALSCROLLDECORATOR_H
+
+#include <QObject>
+
+class QMozVerticalScrollDecorator : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal y READ y NOTIFY yChanged FINAL)
+    Q_PROPERTY(qreal height READ height NOTIFY heightChanged FINAL)
+
+public:
+    QMozVerticalScrollDecorator(QObject *parent = 0);
+    virtual ~QMozVerticalScrollDecorator();
+
+    qreal y() const;
+    void setY(qreal y);
+
+    qreal height() const;
+    void setHeight(qreal height);
+
+Q_SIGNALS:
+    void yChanged();
+    void heightChanged();
+
+private:
+    qreal mY;
+    qreal mHeight;
+};
+
+#endif

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -3,6 +3,9 @@
 
 #include <QVariant>
 
+class QMozVerticalScrollDecorator;
+class QMozHorizontalScrollDecorator;
+
 class QMozReturnValue : public QObject
 {
     Q_OBJECT
@@ -54,7 +57,9 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     Q_PROPERTY(bool painted READ isPainted NOTIFY firstPaint FINAL) \
     Q_PROPERTY(QColor bgcolor READ bgcolor NOTIFY bgColorChanged FINAL) \
     Q_PROPERTY(bool useQmlMouse READ getUseQmlMouse WRITE setUseQmlMouse) \
-    Q_PROPERTY(bool dragging READ dragging NOTIFY draggingChanged FINAL)
+    Q_PROPERTY(bool dragging READ dragging NOTIFY draggingChanged FINAL) \
+    Q_PROPERTY(QMozVerticalScrollDecorator* verticalScrollDecorator READ verticalScrollDecorator FINAL) \
+    Q_PROPERTY(QMozHorizontalScrollDecorator* horizontalScrollDecorator READ horizontalScrollDecorator FINAL)
 
 #define Q_MOZ_VIEW_PUBLIC_METHODS \
     QUrl url() const; \
@@ -76,7 +81,9 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void setUseQmlMouse(bool value); \
     void forceViewActiveFocus(); \
     void createGeckoGLContext(); \
-    bool dragging() const;
+    bool dragging() const; \
+    QMozVerticalScrollDecorator* verticalScrollDecorator() const; \
+    QMozHorizontalScrollDecorator* horizontalScrollDecorator() const;
 
 #define Q_MOZ_VIEW_PUBLIC_SLOTS \
     void loadHtml(const QString& html, const QUrl& baseUrl = QUrl()); \

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -26,6 +26,8 @@
 #include <QSGSimpleTextureNode>
 #include "qgraphicsmozview_p.h"
 #include "EmbedQtKeyUtils.h"
+#include "qmozhorizontalscrolldecorator.h"
+#include "qmozverticalscrolldecorator.h"
 #include "qmozviewsgnode.h"
 #include "qsgthreadobject.h"
 #include "qmcthreadobject.h"
@@ -59,6 +61,8 @@ QuickMozView::QuickMozView(QQuickItem *parent)
     d->mContext = QMozContext::GetInstance();
     connect(this, SIGNAL(setIsActive(bool)), this, SLOT(SetIsActive(bool)));
     connect(this, SIGNAL(updateThreaded()), this, SLOT(update()));
+    connect(this, SIGNAL(enabledChanged()), this, SLOT(updateEnabled()));
+    updateEnabled();
     if (!d->mContext->initialized()) {
         connect(d->mContext, SIGNAL(onInitialized()), this, SLOT(onInitialized()));
     } else {
@@ -103,6 +107,11 @@ QuickMozView::onInitialized()
     }
 }
 
+void QuickMozView::updateEnabled()
+{
+    d->mEnabled = QQuickItem::isEnabled();
+}
+
 void QuickMozView::createGeckoGLContext()
 {
     if (!mMCRenderer && mSGRenderer) {
@@ -139,7 +148,7 @@ void QuickMozView::itemChange(ItemChange change, const ItemChangeData &)
 
 void QuickMozView::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
 {
-    d->mSize = newGeometry.size().toSize();
+    d->mSize = newGeometry.size();
     d->UpdateViewSize();
     QQuickItem::geometryChanged(newGeometry, oldGeometry);
 }
@@ -446,6 +455,16 @@ void QuickMozView::setUseQmlMouse(bool value)
 bool QuickMozView::dragging() const
 {
     return d->mDragging;
+}
+
+QMozVerticalScrollDecorator* QuickMozView::verticalScrollDecorator() const
+{
+    return &d->mVerticalScrollDecorator;
+}
+
+QMozHorizontalScrollDecorator* QuickMozView::horizontalScrollDecorator() const
+{
+    return &d->mHorizontalScrollDecorator;
 }
 
 qreal QuickMozView::contentWidth() const

--- a/src/quickmozview.h
+++ b/src/quickmozview.h
@@ -76,6 +76,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void onInitialized();
+    void updateEnabled();
 
 private:
     QGraphicsMozViewPrivate* d;

--- a/src/src.pro
+++ b/src/src.pro
@@ -21,12 +21,16 @@ isEmpty(VERSION) {
 }
 
 SOURCES += qmozcontext.cpp \
+           qmozhorizontalscrolldecorator.cpp \
+           qmozverticalscrolldecorator.cpp \
            qmessagepump.cpp \
            EmbedQtKeyUtils.cpp \
            qgraphicsmozview_p.cpp \
            geckoworker.cpp
 
 HEADERS += qmozcontext.h \
+           qmozhorizontalscrolldecorator.h \
+           qmozverticalscrolldecorator.h \
            qmessagepump.h \
            EmbedQtKeyUtils.h \
            geckoworker.h \


### PR DESCRIPTION
Vertical and horizontal scroll decorators are not rendering anything.
They are only containing size and positioning information for QML.

I'd like to remove scrollableOffsetChanged altogether but in subsequent PR.
