### PR TITLE
Reset first paint when loading starts

### DIFF
--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -224,8 +224,13 @@ void QGraphicsMozViewPrivate::OnLoadProgress(int32_t aProgress, int32_t aCurTota
 
 void QGraphicsMozViewPrivate::OnLoadStarted(const char* aLocation)
 {
+    if (mIsPainted) {
+        mIsPainted = false;
+        mViewIface->firstPaint(-1, -1);
+    }
+
     if (mLocation != aLocation) {
-        mLocation = aLocation;
+        mLocation = QString(aLocation);
         mViewIface->urlChanged();
     }
     if (!mIsLoading) {


### PR DESCRIPTION
This pull request contains also fix for emitting url changed. As that should also be emitted only if it has changed.
