### PR TITLE
[qtmozembed] Commit preedit text when touching screen if we have preedit...

### DIFF
--- a/src/quickmozview.h
+++ b/src/quickmozview.h
@@ -89,6 +89,7 @@ private:
 #ifndef NO_PRIVATE_API
     bool mInThreadRendering;
 #endif
+    bool mPreedit;
 };
 
 #endif // QuickMozView_H


### PR DESCRIPTION
... text.

Real fix should be such that we would commit text just before moving
the cursor position. As we're currently also missing underline
under preedited text, I think that this is reasonable for time
being.
