### PR TITLE
Add scrollDecoratorChanged signals

### DIFF
--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -60,8 +60,8 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     Q_PROPERTY(bool dragging READ dragging NOTIFY draggingChanged FINAL) \
     Q_PROPERTY(bool moving READ moving NOTIFY movingChanged FINAL) \
     Q_PROPERTY(bool pinching READ pinching NOTIFY pinchingChanged FINAL) \
-    Q_PROPERTY(QMozVerticalScrollDecorator* verticalScrollDecorator READ verticalScrollDecorator FINAL) \
-    Q_PROPERTY(QMozHorizontalScrollDecorator* horizontalScrollDecorator READ horizontalScrollDecorator FINAL) \
+    Q_PROPERTY(QMozVerticalScrollDecorator* verticalScrollDecorator READ verticalScrollDecorator NOTIFY verticalScrollDecoratorChanged FINAL) \
+    Q_PROPERTY(QMozHorizontalScrollDecorator* horizontalScrollDecorator READ horizontalScrollDecorator NOTIFY horizontalScrollDecoratorChanged FINAL) \
     Q_PROPERTY(bool chrome READ chrome WRITE setChrome NOTIFY chromeChanged FINAL) \
     Q_PROPERTY(bool chromeGestureEnabled READ chromeGestureEnabled WRITE setChromeGestureEnabled NOTIFY chromeGestureEnabledChanged FINAL) \
     Q_PROPERTY(qreal chromeGestureThreshold READ chromeGestureThreshold WRITE setChromeGestureThreshold NOTIFY chromeGestureThresholdChanged FINAL)
@@ -152,6 +152,8 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void pinchingChanged(); \
     void contentWidthChanged(); \
     void contentHeightChanged(); \
+    void verticalScrollDecoratorChanged(); \
+    void horizontalScrollDecoratorChanged(); \
     void chromeGestureEnabledChanged(); \
     void chromeChanged(); \
     void chromeGestureThresholdChanged();


### PR DESCRIPTION
The signals are not used by UI, but required in order to avoid
"depends on non-NOTIFYable properties:" warnings.
