### PR TITLE
[qtmozembed] Don't change location when load starts

### DIFF
--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -276,15 +276,13 @@ void QGraphicsMozViewPrivate::OnLoadProgress(int32_t aProgress, int32_t aCurTota
 
 void QGraphicsMozViewPrivate::OnLoadStarted(const char* aLocation)
 {
+    Q_UNUSED(aLocation);
+
     if (mIsPainted) {
         mIsPainted = false;
         mViewIface->firstPaint(-1, -1);
     }
 
-    if (mLocation != aLocation) {
-        mLocation = QString(aLocation);
-        mViewIface->urlChanged();
-    }
     if (!mIsLoading) {
         mIsLoading = true;
         mProgress = 1;


### PR DESCRIPTION
OnLocationChanged is called when url is resolved. E.g. when
url is resolved to download link, location won't change but load starts.
