### PR TITLE
[qtmozembed] Update scroll area from SendAsyncScrollDOMEvent

### DIFF
--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -71,7 +71,7 @@ public:
     virtual void SetIsFocused(bool aIsFocused);
     virtual void CompositorCreated();
 
-    void UpdateContentSize(unsigned int aWidth, unsigned int aHeight);
+    void UpdateScrollArea(unsigned int aWidth, unsigned int aHeight, float aPosX, float aPosY, bool aRootFrame);
     void TestFlickingMode(QTouchEvent *event);
     void HandleTouchEnd(bool& draggingChanged, bool& pinchingChanged);
     void ResetState();


### PR DESCRIPTION
ScrollUpdate is kept still so that we know that user is panning / flicking
root frame.
