### PR TITLE
[qtmozembed] Add read and write parentId property

### DIFF
--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -289,6 +289,11 @@ void QuickMozView::RefreshNodeTexture()
     }
 }
 
+int QuickMozView::parentId() const
+{
+    return mParentID;
+}
+
 bool QuickMozView::Invalidate()
 {
 #ifndef NO_PRIVATE_API
@@ -705,7 +710,11 @@ quint32 QuickMozView::uniqueID() const
 
 void QuickMozView::setParentID(unsigned aParentID)
 {
-    mParentID = aParentID;
+    if (aParentID != mParentID) {
+        mParentID = aParentID;
+        Q_EMIT parentIdChanged();
+    }
+
     if (mParentID) {
         onInitialized();
     }

--- a/src/quickmozview.h
+++ b/src/quickmozview.h
@@ -17,6 +17,7 @@ class QSGThreadObject;
 class QuickMozView : public QQuickItem
 {
     Q_OBJECT
+    Q_PROPERTY(int parentId READ parentId WRITE setParentID NOTIFY parentIdChanged FINAL)
     Q_PROPERTY(unsigned parentid WRITE setParentID)
     Q_PROPERTY(QObject* child READ getChild NOTIFY childChanged)
 
@@ -30,6 +31,8 @@ public:
     void RenderToCurrentContext();
     void startMoveMonitoring();
     void RefreshNodeTexture();
+
+    int parentId() const;
 
 private:
     QObject* getChild() { return this; }
@@ -46,6 +49,7 @@ Q_SIGNALS:
     void wrapRenderThreadGLContext();
     void dispatchItemUpdate();
     void textureReady(int id, const QSize &size);
+    void parentIdChanged();
 
     Q_MOZ_VIEW_SIGNALS
 


### PR DESCRIPTION
When multiple QuickMozView are created this it is good that
parentId can be read so that parent-child window relationships
can checked with this and uniqueID().
