### PR TITLE
Remove obsoleted parentid property

### DIFF
--- a/src/qdeclarativemozview.h
+++ b/src/qdeclarativemozview.h
@@ -19,7 +19,6 @@ class QDeclarativeMozView : public QDeclarativeItem
 
     Q_PROPERTY(int preferredWidth READ preferredWidth WRITE setPreferredWidth NOTIFY preferredWidthChanged)
     Q_PROPERTY(int preferredHeight READ preferredHeight WRITE setPreferredHeight NOTIFY preferredHeightChanged)
-    Q_PROPERTY(unsigned parentid WRITE setParentID)
     Q_PROPERTY(QObject* child READ getChild NOTIFY childChanged)
 public:
     QDeclarativeMozView(QDeclarativeItem *parent = 0);

--- a/src/quickmozview.h
+++ b/src/quickmozview.h
@@ -18,7 +18,6 @@ class QuickMozView : public QQuickItem
 {
     Q_OBJECT
     Q_PROPERTY(int parentId READ parentId WRITE setParentID NOTIFY parentIdChanged FINAL)
-    Q_PROPERTY(unsigned parentid WRITE setParentID)
     Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged FINAL)
     Q_PROPERTY(QObject* child READ getChild NOTIFY childChanged)
 


### PR DESCRIPTION
This was invalidated by compiler.
"quickmozview.h:21: Warning: Property declaration parentid has no READ accessor
function or associated MEMBER variable. The property will be invalid."
