### PR TITLE
[qtmozembed] Appreciate parent clipping

### DIFF
--- a/src/qmozviewsgnode.cpp
+++ b/src/qmozviewsgnode.cpp
@@ -29,7 +29,15 @@ public:
         gfxMatrix matr(affine.m11(), affine.m12(), affine.m21(), affine.m22(), affine.dx(), affine.dy());
         mPrivate->mView->SetGLViewTransform(matr);
         mPrivate->mView->SetViewOpacity(inheritedOpacity());
-        mPrivate->mView->SetViewClipping(0, 0, mPrivate->mSize.width(), mPrivate->mSize.height());
+
+        QRect clipRect(0, 0, mPrivate->mSize.width(), mPrivate->mSize.height());
+        if (mView->parentItem() && mView->parentItem()->clip()) {
+            QRect parentClipRect = mView->parentItem()->clipRect().toRect();
+            if (clipRect.contains(parentClipRect)) {
+                clipRect = parentClipRect;
+            }
+        }
+        mPrivate->mView->SetViewClipping(clipRect.x(), clipRect.y(), clipRect.width(), clipRect.height());
         mPrivate->mView->RenderGL();
     }
 

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -250,7 +250,14 @@ void QuickMozView::RenderToCurrentContext()
     QMatrix affine;
     gfxMatrix matr(affine.m11(), affine.m12(), affine.m21(), affine.m22(), affine.dx(), affine.dy());
     d->mView->SetGLViewTransform(matr);
-    d->mView->SetViewClipping(0, 0, d->mSize.width(), d->mSize.height());
+    QRect clipRect(0, 0, d->mSize.width(), d->mSize.height());
+    if (parentItem() && parentItem()->clip()) {
+        QRect parentClipRect = parentItem()->clipRect().toRect();
+        if (clipRect.contains(parentClipRect)) {
+            clipRect = parentClipRect;
+        }
+    }
+    d->mView->SetViewClipping(clipRect.x(), clipRect.y(), clipRect.width(), clipRect.height());
     d->mView->RenderGL();
 }
 


### PR DESCRIPTION
When parentItem is clipping and its clip rectangle is smaller
than own clip rectangle, use one from parent.
