### PR TITLE
[qtmozembed] Don't resume backgrounded web view

### DIFF
--- a/src/qmozviewsgnode.cpp
+++ b/src/qmozviewsgnode.cpp
@@ -15,7 +15,6 @@ public:
     MozContentSGNode(QGraphicsMozViewPrivate* aPrivate, QuickMozView* aView)
         : mPrivate(aPrivate), mView(aView)
     {
-        mView->setActive(true);
     }
 
     virtual StateFlags changedStates()


### PR DESCRIPTION
The patch fixes the bug when html5 video gets resumed even if the corresponding webview is background:

"1) Opened Browser and a YouTube tab
2) Started to play the video, after a while opened a new tab (Google search), and the YouTube video stopped playing ( which is expected)
3) Swiped the Browser app and it was backgrounded. 
4) Opened the Messages application and replied to a message 
5) Right after I closed the Messages application, the YouTube music started to play again
6) I tapped on Browser cover, opened it and checked that still Google search tab is the active tab in Browser"
