### PR TITLE
[qtmozembed] Send keyevent after each input commit 

### DIFF
--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -386,7 +386,19 @@ void QuickMozView::inputMethodEvent(QInputMethodEvent* event)
                 d->mView->SendTextEvent(event->commitString().toUtf8().data(), event->preeditString().toUtf8().data());
             }
         } else {
-            d->mView->SendTextEvent(event->commitString().toUtf8().data(), event->preeditString().toUtf8().data());
+            if (event->commitString().isEmpty()) {
+                d->mView->SendTextEvent(event->commitString().toUtf8().data(), event->preeditString().toUtf8().data());
+            } else {
+                d->mView->SendTextEvent(event->commitString().toUtf8().data(), event->preeditString().toUtf8().data());
+                // After commiting pre-edit, we send "dummy" keypress.
+                // Workaround for sites that enable "submit" button based on keypress events like
+                // comment fields in FB, and m.linkedin.com
+                // Chrome on Android does the same, but it does it also after each pre-edit change
+                // We cannot do exectly the same here since sending keyevent with active pre-edit would commit gecko's
+                // internal Input Engine's pre-edit
+                d->mView->SendKeyPress(0, 0, 0);
+                d->mView->SendKeyRelease(0, 0, 0);
+            }
         }
     }
 }


### PR DESCRIPTION
This improves handling of sites like m.facebook.com and m.linkedin.com where button next to comment text field only listens to keyevents and ignores composition and input events. With this fix we send dummy keyevent after commit of pre-edit. In practice the button would change into active when user either 1) selects suggested works, commits with space or enter, or commits by tapping somewhere in the UI.

Google Chrome on Android uses similiar approach, but it sends dummy keyevents for each change of pre-edit in addition to commits.
