### PR TITLE
[qtmoezembed] Don't delete QuickMozView in main thread while it's locked...

### DIFF
--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -16,6 +16,7 @@
 
 #include <QTimer>
 #include <QThread>
+#include <QMutexLocker>
 #include <QtOpenGL/QGLContext>
 #include <QGuiApplication>
 #include <QJsonDocument>
@@ -83,6 +84,8 @@ QuickMozView::QuickMozView(QQuickItem *parent)
 
 QuickMozView::~QuickMozView()
 {
+    QMutexLocker locker(&mRenderMutex);
+
     if (d->mView) {
         d->mView->SetListener(NULL);
         d->mContext->GetApp()->DestroyView(d->mView);
@@ -268,6 +271,8 @@ QuickMozView::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data)
 
 void QuickMozView::refreshNodeTexture()
 {
+    QMutexLocker locker(&mRenderMutex);
+
     if (!d->mViewInitialized || !mActive)
         return;
 

--- a/src/quickmozview.h
+++ b/src/quickmozview.h
@@ -7,6 +7,7 @@
 #define QuickMozView_H
 
 #include <QMatrix>
+#include <QMutex>
 #include <QtQuick/QQuickItem>
 #include <QtGui/QOpenGLShaderProgram>
 #include "qmozview_defined_wrapper.h"
@@ -110,6 +111,7 @@ private:
     bool mBackground;
     bool mWindowVisible;
     GLuint mConsTex;
+    QMutex mRenderMutex;
 };
 
 #endif // QuickMozView_H


### PR DESCRIPTION
... by QML render thread.

Otherwise the callees of QuickMozView::refreshNodeTexture() may well try to dereference a NULL pointer.
