### PR TITLE
Repaint web content after GL buffer is recreated

### DIFF
--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -234,6 +234,14 @@ void QuickMozView::clearThreadRenderObject()
 {
     QOpenGLContext* ctx = QOpenGLContext::currentContext();
     Q_ASSERT(ctx != NULL && ctx->makeCurrent(ctx->surface()));
+
+#if defined(QT_OPENGL_ES_2)
+    if (mConsTex) {
+        glDeleteTextures(1, &mConsTex);
+        mConsTex = 0;
+    }
+#endif
+
     QQuickWindow *win = window();
     if (!win) return;
     connect(win, SIGNAL(beforeSynchronizing()), this, SLOT(createThreadRenderObject()), Qt::DirectConnection);
@@ -289,6 +297,8 @@ void QuickMozView::refreshNodeTexture()
 
         if (!mConsTex) {
           glGenTextures(1, &mConsTex);
+          // Call resumeRendering() from the main thread
+          QMetaObject::invokeMethod(this, "resumeRendering", Qt::QueuedConnection);
         }
         glBindTexture(GL_TEXTURE_EXTERNAL_OES, mConsTex);
         void* image = d->mView->GetPlatformImage(&width, &height);
@@ -325,6 +335,9 @@ void QuickMozView::setActive(bool active)
             mActive = active;
             // Process pending paint request before final suspend (unblock possible content Compositor waiters Bug 1020350)
             SetIsActive(active);
+            if (active) {
+                resumeRendering();
+            }
             Q_EMIT activeChanged();
         }
     } else {
@@ -829,6 +842,7 @@ void QuickMozView::suspendView()
     }
     setActive(false);
     d->mView->SuspendTimeouts();
+    d->mView->SuspendRendering();
 }
 
 void QuickMozView::resumeView()
@@ -946,4 +960,9 @@ void QuickMozView::componentComplete()
     } else {
         createView();
     }
+}
+
+void QuickMozView::resumeRendering()
+{
+    d->mView->ResumeRendering();
 }

--- a/src/quickmozview.h
+++ b/src/quickmozview.h
@@ -65,6 +65,7 @@ private Q_SLOTS:
     void processViewInitialization();
     void SetIsActive(bool aIsActive);
     void updateLoaded();
+    void resumeRendering();
 
 // INTERNAL
 protected:


### PR DESCRIPTION
This PR depends on https://github.com/tmeshkova/gecko-dev/pull/33 which is compatible with embedlite_esr only.
