### PR TITLE
Check that node's size is correct when updating geometry after orientation change

### DIFF
--- a/src/qmozextmaterialnode.cpp
+++ b/src/qmozextmaterialnode.cpp
@@ -6,7 +6,6 @@
 #include "qmozextmaterialnode.h"
 #include "quickmozview.h"
 #include <QQuickWindow>
-#include <QThread>
 #include <QOpenGLContext>
 #include <QOpenGLFunctions>
 

--- a/src/qmozextmaterialnode.h
+++ b/src/qmozextmaterialnode.h
@@ -8,7 +8,6 @@
 
 #include <QtQuick/QSGGeometryNode>
 #include <QObject>
-#include <QMutex>
 
 class QuickMozView;
 

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -13,7 +13,6 @@
 #include "mozilla/embedlite/EmbedLiteApp.h"
 #include "mozilla/TimeStamp.h"
 
-#include <QTimer>
 #include <QThread>
 #include <QMutexLocker>
 #include <QGuiApplication>


### PR DESCRIPTION
It might happen that after orientation change when compositing is done `QuickMozView::updatePaintNode()` gets called before a new texture with new geometry has been created. In this case the web page will be squeezed or stretched (reproducible with gecko35). Thus update node's geometry when its size is changed.
