### PR TITLE
[gl] Get back to unconditional texture update

### DIFF
--- a/src/qmozextmaterialnode.cpp
+++ b/src/qmozextmaterialnode.cpp
@@ -62,12 +62,9 @@ public:
 
 };
 
-void MozExtMaterialNode::update(const QSize &size)
+void MozExtMaterialNode::update()
 {
-    // check if the node contains a texture for the current geometry
-    if (m_size == size) {
-        updateGeometry(size);
-    }
+    updateGeometry(m_size);
 }
 
 void MozExtMaterialNode::updateGeometry(const QSize &size)
@@ -99,7 +96,7 @@ MozExtMaterialNode::newTexture(int id, const QSize &size)
     // QuickMozView::updatePaintNode() gets called before a new texture with new
     // geometry has been created. In this case it's safer to reset node's
     // geometry again.
-    if (m_size != size) {
+    if (m_size != size && m_size.width() > 0 && m_size.height() > 0) {
         updateGeometry(size);
     }
 

--- a/src/qmozextmaterialnode.h
+++ b/src/qmozextmaterialnode.h
@@ -17,7 +17,7 @@ public:
 
     ~MozExtMaterialNode() {}
 
-    void update(const QSize &size);
+    void update();
 
 public Q_SLOTS:
 

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -272,7 +272,7 @@ QuickMozView::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data)
         connect(this, SIGNAL(textureReady(int,QSize)), n, SLOT(newTexture(int,QSize)), Qt::DirectConnection);
         connect(window(), SIGNAL(beforeRendering()), n, SLOT(prepareNode()), Qt::DirectConnection);
     }
-    n->update(QSize(width(), height()));
+    n->update();
     return n;
 }
 


### PR DESCRIPTION
It turned out that we're missing compositor updates in case the updates originate from content JS (widget's geometry doesn't change). Thus this PR.
