### PR TITLE
[qtmozembed] Reset painted state immediately on back/forward/reload/load

### DIFF
--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -221,6 +221,14 @@ void QGraphicsMozViewPrivate::UpdateMoving(bool moving)
     }
 }
 
+void QGraphicsMozViewPrivate::ResetPainted()
+{
+    if (mIsPainted) {
+        mIsPainted = false;
+        mViewIface->firstPaint(-1, -1);
+    }
+}
+
 void QGraphicsMozViewPrivate::UpdateViewSize()
 {
     if (mSize.isEmpty())
@@ -295,10 +303,7 @@ void QGraphicsMozViewPrivate::OnLoadStarted(const char* aLocation)
 {
     Q_UNUSED(aLocation);
 
-    if (mIsPainted) {
-        mIsPainted = false;
-        mViewIface->firstPaint(-1, -1);
-    }
+    ResetPainted();
 
     if (!mIsLoading) {
         mIsLoading = true;

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -75,6 +75,7 @@ public:
     void HandleTouchEnd(bool& draggingChanged, bool& pinchingChanged);
     void ResetState();
     void UpdateMoving(bool moving);
+    void ResetPainted();
 
     IMozQViewIface* mViewIface;
     QMozContext* mContext;

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -684,6 +684,8 @@ void QuickMozView::goBack()
 {
     if (!d->mViewInitialized)
         return;
+
+    d->ResetPainted();
     d->mView->GoBack();
 }
 
@@ -691,6 +693,8 @@ void QuickMozView::goForward()
 {
     if (!d->mViewInitialized)
         return;
+
+    d->ResetPainted();
     d->mView->GoForward();
 }
 
@@ -705,6 +709,8 @@ void QuickMozView::reload()
 {
     if (!d->mViewInitialized)
         return;
+
+    d->ResetPainted();
     d->mView->Reload(false);
 }
 
@@ -718,6 +724,7 @@ void QuickMozView::load(const QString& url)
     }
     LOGT("url: %s", url.toUtf8().data());
     d->mProgress = 0;
+    d->ResetPainted();
     d->mView->LoadURL(url.toUtf8().data());
 }
 


### PR DESCRIPTION
x and y coordinates that are passed to firstPaint signal are always
negative when resetting painted state.