### PR TITLE
[qtmozembed] Remove timer from background

### DIFF
--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -47,13 +47,11 @@ QuickMozView::QuickMozView(QQuickItem *parent)
   , mPrivateMode(false)
   , mUseQmlMouse(false)
   , mMovingTimerId(0)
-  , mBackgroundTimerId(0)
   , mOffsetX(0.0)
   , mOffsetY(0.0)
   , mPreedit(false)
   , mActive(false)
   , mBackground(false)
-  , mWindowVisible(false)
   , mLoaded(false)
 {
     static bool Initialized = false;
@@ -312,9 +310,9 @@ void QuickMozView::refreshNodeTexture()
 
 void QuickMozView::windowVisibleChanged(bool visible)
 {
-    mWindowVisible = visible;
-    if (mBackgroundTimerId == 0 && !mBackground) {
-        mBackgroundTimerId = startTimer(1000);
+    if (visible == mBackground) {
+        mBackground = !visible;
+        Q_EMIT backgroundChanged();
     }
 }
 
@@ -953,20 +951,6 @@ void QuickMozView::timerEvent(QTimerEvent *event)
         }
         mOffsetX = offsetX;
         mOffsetY = offsetY;
-    } else if (event->timerId() == mBackgroundTimerId) {
-        if (window()) {
-            // Guard window visibility change was not cancelled after timer triggered.
-            bool windowVisible = window()->isVisible();
-            // mWindowVisible == mBackground visibility changed
-            if (windowVisible == mWindowVisible && mWindowVisible == mBackground) {
-                mBackground = !mWindowVisible;
-                Q_EMIT backgroundChanged();
-                if (mWindowVisible) {
-                    killTimer(mBackgroundTimerId);
-                    mBackgroundTimerId = 0;
-                }
-            }
-        }
     }
 }
 

--- a/src/quickmozview.h
+++ b/src/quickmozview.h
@@ -111,13 +111,11 @@ private:
     bool mPrivateMode;
     bool mUseQmlMouse;
     int mMovingTimerId;
-    int mBackgroundTimerId;
     qreal mOffsetX;
     qreal mOffsetY;
     bool mPreedit;
     bool mActive;
     bool mBackground;
-    bool mWindowVisible;
     bool mLoaded;
     GLuint mConsTex;
     QMutex mRenderMutex;


### PR DESCRIPTION
As we are currently dropping glcontext when the application
using quickmozview becomes invisible (covered by another application), this timer
does not serve any purpose anymore.