### PR TITLE
[qtmozembed] Update view size always when context info is updated

### DIFF
--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -75,7 +75,9 @@ QuickMozView::QuickMozView(QQuickItem *parent)
     connect(this, SIGNAL(dispatchItemUpdate()), this, SLOT(update()));
     connect(this, SIGNAL(loadProgressChanged()), this, SLOT(updateLoaded()));
     connect(this, SIGNAL(loadingChanged()), this, SLOT(updateLoaded()));
-
+    connect(this, &QuickMozView::updateViewSize, this, [=]() {
+        d->UpdateViewSize();
+    });
     updateEnabled();
 }
 
@@ -98,7 +100,6 @@ QuickMozView::SetIsActive(bool aIsActive)
         d->mView->SetIsActive(aIsActive);
         if (mActive) {
             updateGLContextInfo();
-            d->UpdateViewSize();
         }
     } else {
         Q_EMIT setIsActive(aIsActive);
@@ -185,6 +186,7 @@ void QuickMozView::updateGLContextInfo()
         }
 
         d->mGLSurfaceSize = viewPortSize;
+        Q_EMIT updateViewSize();
     }
 }
 
@@ -217,7 +219,6 @@ void QuickMozView::geometryChanged(const QRectF &newGeometry, const QRectF &oldG
         d->mSize = newGeometry.size();
         if (mActive) {
             updateGLContextInfo();
-            d->UpdateViewSize();
         }
     }
 }

--- a/src/quickmozview.h
+++ b/src/quickmozview.h
@@ -62,6 +62,7 @@ Q_SIGNALS:
     void activeChanged();
     void backgroundChanged();
     void loadedChanged();
+    void updateViewSize();
 
     Q_MOZ_VIEW_SIGNALS
 


### PR DESCRIPTION
Previously there was a chance that QGraphicsMozViewPrivate::UpdateViewSize
did not update EmbedLiteView::SetGLViewPortSize because mHasContext was still
false. This in turn led to a crash when EmbedLiteCompositorParent::RenderGL()
tried to publish a frame that was an empty.

This commit adds a updateViewSize signal that is connected to the
QGraphicsMozViewPrivate::UpdateViewSize (normal queued connection). By doing
this QuickMozView::createThreadRenderObject can update mHasContext
and EmbedLiteView::SetGLViewPortSize.

See also: https://github.com/tmeshkova/gecko-dev/pull/45