### PR TITLE
[rendering] Initialize texture pointer to null

### DIFF
--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -53,6 +53,7 @@ QuickMozView::QuickMozView(QQuickItem *parent)
   , mActive(false)
   , mBackground(false)
   , mLoaded(false)
+  , mConsTex(0)
 {
     static bool Initialized = false;
     if (!Initialized) {


### PR DESCRIPTION
Uninitialized pointer seems to be the reason for github.com/tmeshkova/qtmozembed/issues/93

JB#23892