### PR TITLE
[qtmozembed] Remove clearBeforeRendering false

### DIFF
--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -202,7 +202,6 @@ void QuickMozView::itemChange(ItemChange change, const ItemChangeData &)
         connect(win, SIGNAL(beforeSynchronizing()), this, SLOT(createThreadRenderObject()), Qt::DirectConnection);
         connect(win, SIGNAL(sceneGraphInvalidated()), this, SLOT(clearThreadRenderObject()), Qt::DirectConnection);
         connect(win, SIGNAL(visibleChanged(bool)), this, SLOT(windowVisibleChanged(bool)));
-        win->setClearBeforeRendering(false);
     }
 }
 


### PR DESCRIPTION
Don't see reason why we'd have this one. In addition, this has an impact
on rendering performance.