### PR TITLE
[qtmozembed] Remove scrollTo() method from QGraphicsMozView and QuickMozView classes

### DIFF
--- a/src/qgraphicsmozview.cpp
+++ b/src/qgraphicsmozview.cpp
@@ -598,9 +598,3 @@ QGraphicsMozView::synthTouchEnd(const QVariant& touches)
     }
     d->mView->ReceiveInputEvent(meventStart);
 }
-
-void
-QGraphicsMozView::scrollTo(const QPointF& position)
-{
-    LOGT("NOT IMPLEMENTED");
-}

--- a/src/qgraphicsmozview.h
+++ b/src/qgraphicsmozview.h
@@ -57,7 +57,6 @@ public Q_SLOTS:
     void synthTouchBegin(const QVariant& touches);
     void synthTouchMove(const QVariant& touches);
     void synthTouchEnd(const QVariant& touches);
-    void scrollTo(const QPointF& position);
     void suspendView();
     void resumeView();
     void recvMouseMove(int posX, int posY);

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -114,7 +114,6 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void synthTouchBegin(const QVariant& touches); \
     void synthTouchMove(const QVariant& touches); \
     void synthTouchEnd(const QVariant& touches); \
-    void scrollTo(const QPointF& position); \
     void suspendView(); \
     void resumeView(); \
     void recvMouseMove(int posX, int posY); \

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -855,11 +855,6 @@ void QuickMozView::synthTouchEnd(const QVariant& touches)
     d->mView->ReceiveInputEvent(meventStart);
 }
 
-void QuickMozView::scrollTo(const QPointF& position)
-{
-    LOGT("NOT IMPLEMENTED");
-}
-
 void QuickMozView::suspendView()
 {
     if (!d->mView) {


### PR DESCRIPTION
Instead of implementing scrollTo() method, application should scroll by sending 'embedui:scrollTo' message