### PR TITLE
[qtmozembed] Move load, loadFrameScript, addMessageListener(s) to the private class

### DIFF
--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -77,6 +77,11 @@ public:
     void UpdateMoving(bool moving);
     void ResetPainted();
 
+    void load(const QString &url);
+    void loadFrameScript(const QString &frameScript);
+    void addMessageListener(const QString &name);
+    void addMessageListeners(const QStringList &messageNamesList);
+
     IMozQViewIface* mViewIface;
     QMozContext* mContext;
     mozilla::embedlite::EmbedLiteView* mView;
@@ -125,6 +130,10 @@ public:
     bool mPressed;
     bool mDragging;
     bool mFlicking;
+
+    QString mPendingUrl;
+    QStringList mPendingMessageListeners;
+    QStringList mPendingFrameScripts;
 };
 
 qint64 current_timestamp(QTouchEvent*);

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -715,16 +715,7 @@ void QuickMozView::reload()
 
 void QuickMozView::load(const QString& url)
 {
-    if (url.isEmpty())
-        return;
-
-    if (!d->mViewInitialized) {
-        return;
-    }
-    LOGT("url: %s", url.toUtf8().data());
-    d->mProgress = 0;
-    d->ResetPainted();
-    d->mView->LoadURL(url.toUtf8().data());
+    d->load(url);
 }
 
 void QuickMozView::sendAsyncMessage(const QString& name, const QVariant& variant)
@@ -740,27 +731,17 @@ void QuickMozView::sendAsyncMessage(const QString& name, const QVariant& variant
 
 void QuickMozView::addMessageListener(const QString& name)
 {
-    if (!d->mViewInitialized)
-        return;
-
-    d->mView->AddMessageListener(name.toUtf8().data());
+    d->addMessageListener(name);
 }
 
 void QuickMozView::addMessageListeners(const QStringList& messageNamesList)
 {
-    if (!d->mViewInitialized)
-        return;
-
-    nsTArray<nsString> messages;
-    for (int i = 0; i < messageNamesList.size(); i++) {
-        messages.AppendElement((char16_t*)messageNamesList.at(i).data());
-    }
-    d->mView->AddMessageListeners(messages);
+    d->addMessageListeners(messageNamesList);
 }
 
 void QuickMozView::loadFrameScript(const QString& name)
 {
-    d->mView->LoadFrameScript(name.toUtf8().data());
+    d->loadFrameScript(name);
 }
 
 void QuickMozView::newWindow(const QString& url)


### PR DESCRIPTION
This makes possible to call these methods before view is created. When
the view initialized callback is called, pending initialization steps
are executed.