### PR TITLE
Cleanup

### DIFF
--- a/rpm/qtmozembed-qt5.spec
+++ b/rpm/qtmozembed-qt5.spec
@@ -12,7 +12,6 @@ BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5OpenGL)
 BuildRequires:  pkgconfig(Qt5Widgets)
 BuildRequires:  pkgconfig(Qt5Quick)
-BuildRequires:  pkgconfig(Qt5Declarative)
 BuildRequires:  pkgconfig(Qt5QuickTest)
 BuildRequires:  xulrunner-qt5-devel
 BuildRequires:  pkgconfig(nspr)

--- a/src/qmozcontext.cpp
+++ b/src/qmozcontext.cpp
@@ -93,6 +93,10 @@ public:
             mApp->SetIsAccelerated(true);
         }
 #endif
+        if (mPixelRatio != 1.0) {
+            q->setPixelRatio(mPixelRatio);
+        }
+
         setDefaultPrefs();
         mApp->LoadGlobalStyleSheet("chrome://global/content/embedScrollStyles.css", true);
         Q_EMIT q->onInitialized();

--- a/src/qmozcontext.cpp
+++ b/src/qmozcontext.cpp
@@ -70,6 +70,7 @@ public:
             QObject::connect(mThread, SIGNAL(finished()), worker, SLOT(quit()));
             worker->moveToThread(mThread);
 
+            mThread->setObjectName("GeckoWorkerThread");
             mThread->start(QThread::LowPriority);
             return true;
         }
@@ -185,11 +186,6 @@ QMozContext::QMozContext(QObject* parent)
 {
     Q_ASSERT(protectSingleton == nullptr);
     protectSingleton = this;
-}
-
-void QMozContext::setCompositorInSeparateThread(bool aEnabled)
-{
-    d->mApp->SetCompositorInSeparateThread(true);
 }
 
 void QMozContext::setProfile(const QString profilePath)

--- a/src/qmozcontext.h
+++ b/src/qmozcontext.h
@@ -51,7 +51,6 @@ public Q_SLOTS:
     void notifyFirstUIInitialized();
     void setProfile(const QString);
     void addObservers(const QStringList& aObserversList);
-    void setCompositorInSeparateThread(bool aEnabled);
     void setViewCreator(QMozViewCreator* viewCreator);
     quint32 createView(const QString& url, const quint32& parentId = 0);
 

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -120,7 +120,6 @@ void
 QuickMozView::contextInitialized()
 {
     LOGT("QuickMozView");
-    d->mContext->setCompositorInSeparateThread(true);
     // We really don't care about SW rendering on Qt5 anymore
     d->mContext->GetApp()->SetIsAccelerated(true);
     createView();

--- a/tests/qmlmoztestrunner/main.cpp
+++ b/tests/qmlmoztestrunner/main.cpp
@@ -62,7 +62,6 @@ int main(int argc, char **argv)
             QTimer::singleShot(0, &runn, SLOT(DropInStartup()));
             // These components must be loaded before app start
             QString componentPath(DEFAULT_COMPONENTS_PATH);
-            QMozContext::GetInstance()->setCompositorInSeparateThread(true);
             QMozContext::GetInstance()->addComponentManifest(componentPath + QString("/components") + QString("/EmbedLiteBinComponents.manifest"));
             QMozContext::GetInstance()->addComponentManifest(componentPath + QString("/chrome") + QString("/EmbedLiteJSScripts.manifest"));
             QMozContext::GetInstance()->addComponentManifest(componentPath + QString("/chrome") + QString("/EmbedLiteOverrides.manifest"));


### PR DESCRIPTION
Contains two commits:
1) Adds pixel ratio preference setting to the context initialized 
2) Clean up stuff
    - setCompositorInSeparateThread is deprecated in EmbedLiteApp.
    - give a name for the gecko worker thread
    - remove obsolete build requires