### PR TITLE
[qtmozembed] Move text input handling to the private class

### DIFF
--- a/src/qgraphicsmozview.cpp
+++ b/src/qgraphicsmozview.cpp
@@ -14,7 +14,6 @@
 #include <QtOpenGL/QGLContext>
 #include <QJsonDocument>
 #include <QJsonParseError>
-#include "EmbedQtKeyUtils.h"
 
 #include "qgraphicsmozview.h"
 #include "qmozcontext.h"
@@ -487,45 +486,17 @@ void QGraphicsMozView::mouseReleaseEvent(QGraphicsSceneMouseEvent* e)
 
 void QGraphicsMozView::inputMethodEvent(QInputMethodEvent* event)
 {
-    LOGT("cStr:%s, preStr:%s, replLen:%i, replSt:%i", event->commitString().toUtf8().data(), event->preeditString().toUtf8().data(), event->replacementLength(), event->replacementStart());
-    if (d->mViewInitialized) {
-        d->mView->SendTextEvent(event->commitString().toUtf8().data(), event->preeditString().toUtf8().data());
-    }
+    d->inputMethodEvent(event);
 }
 
 void QGraphicsMozView::keyPressEvent(QKeyEvent* event)
 {
-    if (!d->mViewInitialized)
-        return;
-
-    int32_t gmodifiers = MozKey::QtModifierToDOMModifier(event->modifiers());
-    int32_t domKeyCode = MozKey::QtKeyCodeToDOMKeyCode(event->key(), event->modifiers());
-    int32_t charCode = 0;
-    if (event->text().length() && event->text()[0].isPrint()) {
-        charCode = (int32_t)event->text()[0].unicode();
-        if (getenv("USE_TEXT_EVENTS")) {
-            return;
-        }
-    }
-    d->mView->SendKeyPress(domKeyCode, gmodifiers, charCode);
+    d->keyPressEvent(event);
 }
 
 void QGraphicsMozView::keyReleaseEvent(QKeyEvent* event)
 {
-    if (!d->mViewInitialized)
-        return;
-
-    int32_t gmodifiers = MozKey::QtModifierToDOMModifier(event->modifiers());
-    int32_t domKeyCode = MozKey::QtKeyCodeToDOMKeyCode(event->key(), event->modifiers());
-    int32_t charCode = 0;
-    if (event->text().length() && event->text()[0].isPrint()) {
-        charCode = (int32_t)event->text()[0].unicode();
-        if (getenv("USE_TEXT_EVENTS")) {
-            d->mView->SendTextEvent(event->text().toUtf8().data(), "");
-            return;
-        }
-    }
-    d->mView->SendKeyRelease(domKeyCode, gmodifiers, charCode);
+    d->keyReleaseEvent(event);
 }
 
 QVariant

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -84,6 +84,10 @@ public:
 
     void startMoveMonitor();
     void timerEvent(QTimerEvent *event);
+    QVariant inputMethodQuery(Qt::InputMethodQuery property) const;
+    void inputMethodEvent(QInputMethodEvent *event);
+    void keyPressEvent(QKeyEvent *event);
+    void keyReleaseEvent(QKeyEvent *event);
 
     IMozQViewIface* mViewIface;
     QScopedPointer<QObject> q;
@@ -128,6 +132,7 @@ public:
     bool mIsPainted;
     Qt::InputMethodHints mInputMethodHints;
     bool mIsInputFieldFocused;
+    bool mPreedit;
     bool mViewIsFocused;
     bool mHasContext;
     QSize mGLSurfaceSize;

--- a/src/quickmozview.h
+++ b/src/quickmozview.h
@@ -109,7 +109,6 @@ private:
     unsigned mParentID;
     bool mPrivateMode;
     bool mUseQmlMouse;
-    bool mPreedit;
     bool mActive;
     bool mBackground;
     bool mLoaded;


### PR DESCRIPTION
Move inputMethodQuery, inputMethodEvent, keyPressEvent, and
keyReleaseEvent to the private class.

This is preparation for opengl based public interface / generic cleanup.