### PR TITLE
[qtmozembed] Add a web page supporing OMTC and external window/surface

### DIFF
--- a/src/qgraphicsmozview.cpp
+++ b/src/qgraphicsmozview.cpp
@@ -101,6 +101,12 @@ QGraphicsMozView::CompositingFinished()
 {
 }
 
+bool
+QGraphicsMozView::Invalidate()
+{
+    return false;
+}
+
 void
 QGraphicsMozView::OnUpdateThreaded()
 {

--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -463,6 +463,11 @@ void QGraphicsMozViewPrivate::SetBackgroundColor(uint8_t r, uint8_t g, uint8_t b
     mViewIface->bgColorChanged();
 }
 
+bool QGraphicsMozViewPrivate::Invalidate()
+{
+    return mViewIface->Invalidate();
+}
+
 void QGraphicsMozViewPrivate::CompositingFinished()
 {
     mViewIface->CompositingFinished();

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -37,6 +37,7 @@ public:
     virtual bool RequestCurrentGLContext();
     virtual void ViewInitialized();
     virtual void SetBackgroundColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+    virtual bool Invalidate();
     virtual void CompositingFinished();
     virtual void OnLocationChanged(const char* aLocation, bool aCanGoBack, bool aCanGoForward);
     virtual void OnLoadProgress(int32_t aProgress, int32_t aCurTotal, int32_t aMaxTotal);

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -2,6 +2,13 @@
 #define qmozview_defined_wrapper_h
 
 #include <QVariant>
+#include <QColor>
+#include <QUrl>
+#include <QRectF>
+#include <QSizeF>
+#include <QString>
+#include <QPoint>
+#include <QPointF>
 
 class QMozScrollDecorator;
 
@@ -120,6 +127,7 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void recvMousePress(int posX, int posY); \
     void recvMouseRelease(int posX, int posY); \
     void CompositingFinished(); \
+    bool Invalidate(); \
     void requestGLContext(bool& hasContext, QSize& viewPortSize);
 
 #define Q_MOZ_VIEW_SIGNALS \

--- a/src/qmozview_templated_wrapper.h
+++ b/src/qmozview_templated_wrapper.h
@@ -16,6 +16,7 @@ public:
     virtual ~IMozQViewIface() {}
     // Methods
     virtual void CompositingFinished() = 0;
+    virtual bool Invalidate() = 0;
     virtual void setInputMethodHints(Qt::InputMethodHints hints) = 0;
     virtual void forceViewActiveFocus() = 0;
     virtual void createGeckoGLContext() = 0;
@@ -60,6 +61,11 @@ public:
     void CompositingFinished()
     {
         view.CompositingFinished();
+    }
+
+    bool Invalidate()
+    {
+        return view.Invalidate();
     }
 
     void setInputMethodHints(Qt::InputMethodHints hints)

--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -1,0 +1,624 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "qopenglwebpage.h"
+
+#include "qmozcontext.h"
+#include "qmozembedlog.h"
+#include "mozilla/embedlite/EmbedLiteView.h"
+#include "mozilla/embedlite/EmbedLiteApp.h"
+
+#include <qglobal.h>
+#include <qqmlinfo.h>
+
+#include "qgraphicsmozview_p.h"
+#include "qmozscrolldecorator.h"
+
+#define LOG_COMPONENT "QOpenGLWebPage"
+
+using namespace mozilla;
+using namespace mozilla::embedlite;
+
+/*!
+    \fn void QOpenGLWebPage::QOpenGLWebPage(QObject *parent)
+
+    In order to use this, MOZ_USE_EXTERNAL_WINDOW environment variable needs to be set. The
+    MOZ_USE_EXTERNAL_WINDOW will take higher precedence than MOZ_LAYERS_PREFER_OFFSCREEN.
+
+    \sa QOpenGLWebPage::requestGLContext()
+*/
+QOpenGLWebPage::QOpenGLWebPage(QObject *parent)
+  : QObject(parent)
+  , d(new QGraphicsMozViewPrivate(new IMozQView<QOpenGLWebPage>(*this), this))
+  , mParentID(0)
+  , mPrivateMode(false)
+  , mActive(true)
+  , mBackground(false)
+  , mLoaded(false)
+  , mCompleted(false)
+{
+    d->mContext = QMozContext::GetInstance();
+    d->mHasContext = true;
+
+    connect(this, SIGNAL(setIsActive(bool)), this, SLOT(SetIsActive(bool)));
+    connect(this, SIGNAL(viewInitialized()), this, SLOT(processViewInitialization()));
+    connect(this, SIGNAL(loadProgressChanged()), this, SLOT(updateLoaded()));
+    connect(this, SIGNAL(loadingChanged()), this, SLOT(updateLoaded()));
+
+    if (!d->mContext->initialized()) {
+        connect(d->mContext, SIGNAL(onInitialized()), this, SLOT(createView()));
+    } else {
+        createView();
+    }
+}
+
+QOpenGLWebPage::~QOpenGLWebPage()
+{
+    if (d->mView) {
+        d->mView->SetListener(NULL);
+        d->mContext->GetApp()->DestroyView(d->mView);
+    }
+    delete d;
+}
+
+void QOpenGLWebPage::SetIsActive(bool aIsActive)
+{
+    if (d->mView) {
+        d->mView->SetIsActive(aIsActive);
+        if (aIsActive) {
+            d->mView->ResumeRendering();
+        } else {
+            d->mView->SuspendRendering();
+        }
+    }
+}
+
+void QOpenGLWebPage::updateLoaded()
+{
+    bool loaded = loadProgress() == 100 && !loading();
+    if (mLoaded != loaded) {
+        mLoaded = loaded;
+        Q_EMIT loadedChanged();
+    }
+}
+
+void QOpenGLWebPage::createView()
+{
+    LOGT("QOpenGLWebPage");
+    if (!d->mView) {
+        // We really don't care about SW rendering on Qt5 anymore
+        d->mContext->GetApp()->SetIsAccelerated(true);
+        d->mView = d->mContext->GetApp()->CreateView(mParentID, mPrivateMode);
+        d->mView->SetListener(d);
+    }
+}
+
+void QOpenGLWebPage::processViewInitialization()
+{
+    // This is connected to view initialization. View must be initialized
+    // over here.
+    Q_ASSERT(d->mViewInitialized);
+
+    mCompleted = true;
+    forceActiveFocus();
+    Q_EMIT completedChanged();
+}
+
+void QOpenGLWebPage::createGeckoGLContext()
+{
+}
+
+/*!
+    \fn void QOpenGLWebPage::requestGLContext()
+
+    With in the slot connected to the requestGLContext() prepare QOpenGLContext and
+    make it current context of the gecko compositor thread,
+    against the surface of the QWindow.
+
+    \code
+    m_context = new QOpenGLContext();
+    m_context->setFormat(requestedFormat());
+    m_context->create();
+    m_context->makeCurrent(this);
+    \endcode
+
+    This signal is emitted from the gecko compositor thread, you must make sure that
+    the connection is direct (see Qt::ConnectionType)
+
+    \sa QOpenGLContext::makeCurrent(QSurface*)
+*/
+void QOpenGLWebPage::requestGLContext(bool& hasContext, QSize& viewPortSize)
+{
+    hasContext = true;
+    viewPortSize = d->mGLSurfaceSize;
+    Q_EMIT requestGLContext();
+}
+
+void QOpenGLWebPage::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
+{
+    LOGT("newGeometry size: [%g, %g] oldGeometry size: [%g,%g]", newGeometry.size().width(),
+                                                                 newGeometry.size().height(),
+                                                                 oldGeometry.size().width(),
+                                                                 oldGeometry.size().height());
+    setSize(newGeometry.size());
+}
+
+int QOpenGLWebPage::parentId() const
+{
+    return mParentID;
+}
+
+bool QOpenGLWebPage::privateMode() const
+{
+    return mPrivateMode;
+}
+
+void QOpenGLWebPage::setPrivateMode(bool privateMode)
+{
+    if (d->mView) {
+        // View is created directly in componentComplete() if mozcontext ready
+        qmlInfo(this) << "privateMode cannot be changed after view is created";
+        return;
+    }
+
+    if (privateMode != mPrivateMode) {
+        mPrivateMode = privateMode;
+        Q_EMIT privateModeChanged();
+    }
+}
+
+bool QOpenGLWebPage::enabled() const
+{
+    return d->mEnabled;
+}
+
+void QOpenGLWebPage::setEnabled(bool enabled)
+{
+    if (d->mEnabled != enabled) {
+        d->mEnabled = enabled;
+        Q_EMIT enabledChanged();
+    }
+}
+
+bool QOpenGLWebPage::active() const
+{
+    return mActive;
+}
+
+void QOpenGLWebPage::setActive(bool active)
+{
+    if (d->mViewInitialized) {
+        if (mActive != active) {
+            mActive = active;
+            Q_EMIT activeChanged();
+        }
+        SetIsActive(active);
+    } else {
+        // Will be processed once view is initialized.
+        mActive = active;
+    }
+}
+
+qreal QOpenGLWebPage::width() const
+{
+    return d->mSize.width();
+}
+
+void QOpenGLWebPage::setWidth(qreal width)
+{
+    QSizeF newSize(width, d->mSize.height());
+    setSize(newSize);
+}
+
+qreal QOpenGLWebPage::height() const
+{
+    return d->mSize.height();
+}
+
+void QOpenGLWebPage::setHeight(qreal height)
+{
+    QSizeF newSize(d->mSize.width(), height);
+    setSize(newSize);
+}
+
+QSizeF QOpenGLWebPage::size() const
+{
+    return d->mSize;
+}
+
+void QOpenGLWebPage::setSize(const QSizeF &size)
+{
+    if (d->mSize == size) {
+        return;
+    }
+
+    bool widthWillChanged = d->mSize.width() != size.width();
+    bool heightWillChanged = d->mSize.height() != size.height();
+
+    d->mSize = size;
+    d->mGLSurfaceSize = size.toSize();
+    d->UpdateViewSize();
+
+    if (widthWillChanged) {
+        Q_EMIT widthChanged();
+    }
+
+    if (heightWillChanged) {
+        Q_EMIT heightChanged();
+    }
+
+    Q_EMIT sizeChanged();
+}
+
+bool QOpenGLWebPage::background() const
+{
+    return mBackground;
+}
+
+void QOpenGLWebPage::setBackground(bool background)
+{
+    if (mBackground == background) {
+        return;
+    }
+
+    mBackground = background;
+    Q_EMIT backgroundChanged();
+}
+
+bool QOpenGLWebPage::loaded() const
+{
+    return mLoaded;
+}
+
+bool QOpenGLWebPage::Invalidate()
+{
+    return true;
+}
+
+void QOpenGLWebPage::CompositingFinished()
+{
+}
+
+bool QOpenGLWebPage::completed() const
+{
+    return mCompleted;
+}
+
+void QOpenGLWebPage::forceActiveFocus()
+{
+    Q_ASSERT(d->mViewInitialized);
+    setActive(true);
+    d->mView->SetIsFocused(true);
+}
+
+void QOpenGLWebPage::setInputMethodHints(Qt::InputMethodHints hints)
+{
+    d->mInputMethodHints = hints;
+}
+
+void QOpenGLWebPage::inputMethodEvent(QInputMethodEvent* event)
+{
+    d->inputMethodEvent(event);
+}
+
+void QOpenGLWebPage::keyPressEvent(QKeyEvent* event)
+{
+    d->keyPressEvent(event);
+}
+
+void QOpenGLWebPage::keyReleaseEvent(QKeyEvent* event)
+{
+    return d->keyReleaseEvent(event);
+}
+
+QVariant QOpenGLWebPage::inputMethodQuery(Qt::InputMethodQuery property) const
+{
+    return d->inputMethodQuery(property);
+}
+
+void QOpenGLWebPage::focusInEvent(QFocusEvent* event)
+{
+    Q_UNUSED(event);
+    d->SetIsFocused(true);
+}
+
+void QOpenGLWebPage::focusOutEvent(QFocusEvent* event)
+{
+    Q_UNUSED(event);
+    d->SetIsFocused(false);
+}
+
+void QOpenGLWebPage::forceViewActiveFocus()
+{
+    forceActiveFocus();
+}
+
+QUrl QOpenGLWebPage::url() const
+{
+    return QUrl(d->mLocation);
+}
+
+void QOpenGLWebPage::setUrl(const QUrl& url)
+{
+    load(url.toString());
+}
+
+QString QOpenGLWebPage::title() const
+{
+    return d->mTitle;
+}
+
+int QOpenGLWebPage::loadProgress() const
+{
+    return d->mProgress;
+}
+
+bool QOpenGLWebPage::canGoBack() const
+{
+    return d->mCanGoBack;
+}
+
+bool QOpenGLWebPage::canGoForward() const
+{
+    return d->mCanGoForward;
+}
+
+bool QOpenGLWebPage::loading() const
+{
+    return d->mIsLoading;
+}
+
+QRectF QOpenGLWebPage::contentRect() const
+{
+    return d->mContentRect;
+}
+
+QSizeF QOpenGLWebPage::scrollableSize() const
+{
+    return d->mScrollableSize;
+}
+
+QPointF QOpenGLWebPage::scrollableOffset() const
+{
+    return d->mScrollableOffset;
+}
+
+float QOpenGLWebPage::resolution() const
+{
+    return d->mContentResolution;
+}
+
+bool QOpenGLWebPage::isPainted() const
+{
+    return d->mIsPainted;
+}
+
+QColor QOpenGLWebPage::bgcolor() const
+{
+    return d->mBgColor;
+}
+
+bool QOpenGLWebPage::getUseQmlMouse()
+{
+    return false;
+}
+
+void QOpenGLWebPage::setUseQmlMouse(bool value)
+{
+    Q_UNUSED(value);
+}
+
+bool QOpenGLWebPage::dragging() const
+{
+    return d->mDragging;
+}
+
+bool QOpenGLWebPage::moving() const
+{
+    return d->mMoving;
+}
+
+bool QOpenGLWebPage::pinching() const{
+    return d->mPinching;
+}
+
+QMozScrollDecorator* QOpenGLWebPage::verticalScrollDecorator() const
+{
+    return &d->mVerticalScrollDecorator;
+}
+
+QMozScrollDecorator* QOpenGLWebPage::horizontalScrollDecorator() const
+{
+    return &d->mHorizontalScrollDecorator;
+}
+
+bool QOpenGLWebPage::chromeGestureEnabled() const
+{
+    return d->mChromeGestureEnabled;
+}
+
+void QOpenGLWebPage::setChromeGestureEnabled(bool value)
+{
+    if (value != d->mChromeGestureEnabled) {
+        d->mChromeGestureEnabled = value;
+        Q_EMIT chromeGestureEnabledChanged();
+    }
+}
+
+qreal QOpenGLWebPage::chromeGestureThreshold() const
+{
+    return d->mChromeGestureThreshold;
+}
+
+void QOpenGLWebPage::setChromeGestureThreshold(qreal value)
+{
+    if (value != d->mChromeGestureThreshold) {
+        d->mChromeGestureThreshold = value;
+        Q_EMIT chromeGestureThresholdChanged();
+    }
+}
+
+bool QOpenGLWebPage::chrome() const
+{
+    return d->mChrome;
+}
+
+void QOpenGLWebPage::setChrome(bool value)
+{
+    if (value != d->mChrome) {
+        d->mChrome = value;
+        Q_EMIT chromeChanged();
+    }
+}
+
+qreal QOpenGLWebPage::contentWidth() const
+{
+    return d->mScrollableSize.width();
+}
+
+qreal QOpenGLWebPage::contentHeight() const
+{
+    return d->mScrollableSize.height();
+}
+
+void QOpenGLWebPage::loadHtml(const QString& html, const QUrl& baseUrl)
+{
+    LOGT();
+}
+
+void QOpenGLWebPage::goBack()
+{
+    if (!d->mViewInitialized)
+        return;
+    d->mView->GoBack();
+}
+
+void QOpenGLWebPage::goForward()
+{
+    if (!d->mViewInitialized)
+        return;
+    d->mView->GoForward();
+}
+
+void QOpenGLWebPage::stop()
+{
+    if (!d->mViewInitialized)
+        return;
+    d->mView->StopLoad();
+}
+
+void QOpenGLWebPage::reload()
+{
+    if (!d->mViewInitialized)
+        return;
+    d->ResetPainted();
+    d->mView->Reload(false);
+}
+
+void QOpenGLWebPage::load(const QString& url)
+{
+    d->load(url);
+}
+
+void QOpenGLWebPage::sendAsyncMessage(const QString& name, const QVariant& variant)
+{
+    d->sendAsyncMessage(name, variant);
+}
+
+void QOpenGLWebPage::addMessageListener(const QString& name)
+{
+    d->addMessageListener(name);
+}
+
+void QOpenGLWebPage::addMessageListeners(const QStringList& messageNamesList)
+{
+    d->addMessageListeners(messageNamesList);
+}
+
+void QOpenGLWebPage::loadFrameScript(const QString& name)
+{
+    d->loadFrameScript(name);
+}
+
+void QOpenGLWebPage::newWindow(const QString& url)
+{
+    LOGT("New Window: %s", url.toUtf8().data());
+}
+
+quint32 QOpenGLWebPage::uniqueID() const
+{
+    return d->mView ? d->mView->GetUniqueID() : 0;
+}
+
+void QOpenGLWebPage::setParentID(unsigned aParentID)
+{
+    if (aParentID != mParentID) {
+        mParentID = aParentID;
+        Q_EMIT parentIdChanged();
+    }
+
+    if (mParentID) {
+        createView();
+    }
+}
+
+void QOpenGLWebPage::synthTouchBegin(const QVariant& touches)
+{
+    Q_UNUSED(touches);
+}
+
+void QOpenGLWebPage::synthTouchMove(const QVariant& touches)
+{
+    Q_UNUSED(touches);
+}
+
+void QOpenGLWebPage::synthTouchEnd(const QVariant& touches)
+{
+    Q_UNUSED(touches);
+}
+
+void QOpenGLWebPage::suspendView()
+{
+    if (!d->mView) {
+        return;
+    }
+    setActive(false);
+    d->mView->SuspendTimeouts();
+}
+
+void QOpenGLWebPage::resumeView()
+{
+    if (!d->mView) {
+        return;
+    }
+    setActive(true);
+    d->mView->ResumeTimeouts();
+}
+
+void QOpenGLWebPage::recvMouseMove(int posX, int posY)
+{
+    Q_ASSERT_X(false, "QOpenGLWebPage", "calling recvMouseMove not supported!");
+}
+
+void QOpenGLWebPage::recvMousePress(int posX, int posY)
+{
+    Q_ASSERT_X(false, "QOpenGLWebPage", "calling recvMousePress not supported!");
+}
+
+void QOpenGLWebPage::recvMouseRelease(int posX, int posY)
+{
+    Q_ASSERT_X(false, "QOpenGLWebPage", "calling recvMouseRelease not supported!");
+}
+
+void QOpenGLWebPage::touchEvent(QTouchEvent *event)
+{
+    d->touchEvent(event);
+    event->accept();
+}
+
+void QOpenGLWebPage::timerEvent(QTimerEvent *event)
+{
+    d->timerEvent(event);
+}

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -1,0 +1,124 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef QOPENGLWEBPAGE_H
+#define QOPENGLWEBPAGE_H
+
+#include <qqml.h>
+#include <QSizeF>
+
+// Needed events, all of these renders to qevent.h includes.
+#include <QMouseEvent>
+#include <QInputMethodEvent>
+#include <QKeyEvent>
+#include <QFocusEvent>
+#include <QTouchEvent>
+
+#include "qmozview_defined_wrapper.h"
+
+class QGraphicsMozViewPrivate;
+
+class QOpenGLWebPage : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int parentId READ parentId WRITE setParentID NOTIFY parentIdChanged FINAL)
+    Q_PROPERTY(bool privateMode READ privateMode WRITE setPrivateMode NOTIFY privateModeChanged FINAL)
+
+    Q_PROPERTY(bool completed READ completed NOTIFY completedChanged FINAL)
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged FINAL)
+    Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged FINAL)
+    Q_PROPERTY(qreal width READ width WRITE setWidth NOTIFY widthChanged FINAL)
+    Q_PROPERTY(qreal height READ height WRITE setHeight NOTIFY heightChanged FINAL)
+    Q_PROPERTY(QSizeF size READ size WRITE setSize NOTIFY sizeChanged FINAL)
+
+    Q_PROPERTY(bool background READ background WRITE setBackground NOTIFY backgroundChanged FINAL)
+    Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged FINAL)
+
+    Q_MOZ_VIEW_PRORERTIES
+
+public:
+    QOpenGLWebPage(QObject *parent = 0);
+    ~QOpenGLWebPage();
+
+    Q_MOZ_VIEW_PUBLIC_METHODS
+    int parentId() const;
+
+    bool privateMode() const;
+    void setPrivateMode(bool privateMode);
+
+    bool completed() const;
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+    bool active() const;
+    void setActive(bool active);
+
+    qreal width() const;
+    void setWidth(qreal width);
+
+    qreal height() const;
+    void setHeight(qreal height);
+
+    QSizeF size() const;
+    void setSize(const QSizeF &size);
+
+    bool background() const;
+    void setBackground(bool background);
+
+    bool loaded() const;
+
+    virtual void geometryChanged(const QRectF & newGeometry, const QRectF & oldGeometry);
+    virtual QVariant inputMethodQuery(Qt::InputMethodQuery property) const;
+    virtual void inputMethodEvent(QInputMethodEvent* event);
+    virtual void keyPressEvent(QKeyEvent*);
+    virtual void keyReleaseEvent(QKeyEvent*);
+    virtual void focusInEvent(QFocusEvent*);
+    virtual void focusOutEvent(QFocusEvent*);
+    virtual void touchEvent(QTouchEvent*);
+    virtual void timerEvent(QTimerEvent*);
+
+public Q_SLOTS:
+    Q_MOZ_VIEW_PUBLIC_SLOTS
+    void forceActiveFocus();
+    void setInputMethodHints(Qt::InputMethodHints hints);
+
+Q_SIGNALS:
+    void setIsActive(bool);
+    void parentIdChanged();
+    void privateModeChanged();
+    void completedChanged();
+    void enabledChanged();
+    void activeChanged();
+    void widthChanged();
+    void heightChanged();
+    void sizeChanged();
+    void backgroundChanged();
+    void loadedChanged();
+    void requestGLContext();
+
+    Q_MOZ_VIEW_SIGNALS
+
+private Q_SLOTS:
+    void processViewInitialization();
+    void SetIsActive(bool aIsActive);
+    void updateLoaded();
+    void createView();
+
+private:
+    QGraphicsMozViewPrivate* d;
+    friend class QGraphicsMozViewPrivate;
+
+    unsigned mParentID;
+    bool mPrivateMode;
+    bool mActive;
+    bool mBackground;
+    bool mLoaded;
+    bool mCompleted;
+};
+
+QML_DECLARE_TYPE(QOpenGLWebPage)
+
+#endif // QOPENGLWEBPAGE_H

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -128,7 +128,7 @@ void QuickMozView::createGeckoGLContext()
 
 void QuickMozView::requestGLContext(bool& hasContext, QSize& viewPortSize)
 {
-    hasContext = false;
+    hasContext = true;
     viewPortSize = d->mGLSurfaceSize;
 }
 
@@ -345,6 +345,11 @@ bool QuickMozView::loaded() const
 void QuickMozView::CompositingFinished()
 {
     Q_EMIT dispatchItemUpdate();
+}
+
+bool QuickMozView::Invalidate()
+{
+    return false;
 }
 
 void QuickMozView::cleanup()

--- a/src/src.pro
+++ b/src/src.pro
@@ -21,7 +21,8 @@ SOURCES += qmozcontext.cpp \
            qmessagepump.cpp \
            EmbedQtKeyUtils.cpp \
            qgraphicsmozview_p.cpp \
-           geckoworker.cpp
+           geckoworker.cpp \
+           qopenglwebpage.cpp
 
 HEADERS += qmozcontext.h \
            qmozviewcreator.h \
@@ -31,7 +32,8 @@ HEADERS += qmozcontext.h \
            qgraphicsmozview_p.h \
            geckoworker.h \
            qmozview_defined_wrapper.h \
-           qmozview_templated_wrapper.h
+           qmozview_templated_wrapper.h \
+           qopenglwebpage.h
 
 SOURCES += quickmozview.cpp qmoztexturenode.cpp qmozextmaterialnode.cpp
 HEADERS += quickmozview.h qmoztexturenode.h qmozextmaterialnode.h


### PR DESCRIPTION
Work-in-progress do not merge until required dependencies are merged!

MOZ_USE_EXTERNAL_WINDOW environment variable needs to be set.

This also requires that EmbedLitePuppetWidget requests gl context and
MOZ_LAYERS_PREFER_OFFSCREEN is not set by EmbedLiteAppThreadParent.

Meaning that following embedlite pull requests are needed:
https://github.com/tmeshkova/gecko-dev/pull/48
https://github.com/nemomobile-packages/gecko-dev/pull/4
https://github.com/nemomobile-packages/gecko-dev/pull/5 (same as https://github.com/tmeshkova/gecko-dev/pull/48 but against gecko 31)

https://github.com/tmeshkova/qtmozembed/pull/112
https://github.com/tmeshkova/qtmozembed/pull/113
https://github.com/tmeshkova/qtmozembed/pull/114
https://github.com/tmeshkova/qtmozembed/pull/115
https://github.com/tmeshkova/qtmozembed/pull/116
https://github.com/tmeshkova/qtmozembed/pull/117