### PR TITLE
[qtmozembed] Don't pass calls through before view is initialized.

### DIFF
--- a/src/qgraphicsmozview.cpp
+++ b/src/qgraphicsmozview.cpp
@@ -328,7 +328,7 @@ bool QGraphicsMozView::event(QEvent* event)
 
 void QGraphicsMozView::suspendView()
 {
-    if (!d->mView) {
+    if (!d->mViewInitialized) {
         return;
     }
     d->mView->SetIsActive(false);
@@ -337,7 +337,7 @@ void QGraphicsMozView::suspendView()
 
 void QGraphicsMozView::resumeView()
 {
-    if (!d->mView) {
+    if (!d->mViewInitialized) {
         return;
     }
     d->mView->SetIsActive(true);

--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -261,7 +261,7 @@ void QGraphicsMozViewPrivate::load(const QString &url)
 
 void QGraphicsMozViewPrivate::loadFrameScript(const QString &frameScript)
 {
-    if (!mView) {
+    if (!mViewInitialized) {
         mPendingFrameScripts.append(frameScript);
     } else {
         mView->LoadFrameScript(frameScript.toUtf8().data());

--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -581,7 +581,7 @@ void QOpenGLWebPage::synthTouchEnd(const QVariant& touches)
 
 void QOpenGLWebPage::suspendView()
 {
-    if (!d->mView) {
+    if (!d->mViewInitialized) {
         return;
     }
     setActive(false);
@@ -590,7 +590,7 @@ void QOpenGLWebPage::suspendView()
 
 void QOpenGLWebPage::resumeView()
 {
-    if (!d->mView) {
+    if (!d->mViewInitialized) {
         return;
     }
     setActive(true);

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -743,7 +743,7 @@ void QuickMozView::synthTouchEnd(const QVariant& touches)
 
 void QuickMozView::suspendView()
 {
-    if (!d->mView) {
+    if (!d->mViewInitialized) {
         return;
     }
     setActive(false);
@@ -753,7 +753,7 @@ void QuickMozView::suspendView()
 
 void QuickMozView::resumeView()
 {
-    if (!d->mView) {
+    if (!d->mViewInitialized) {
         return;
     }
     setActive(true);


### PR DESCRIPTION
Without this fix following kind of error messages are printed when
LoadFrameScript, ResumeView, or SuspendView is called before view is initialized:

IPDL protocol error: Handler for LoadFrameScript returned error code
deserialized, but the handler returned false (indicating failure)