### PR TITLE
[qtmozembed] Add draw underlay implementation.

### DIFF
--- a/src/qgraphicsmozview.cpp
+++ b/src/qgraphicsmozview.cpp
@@ -125,6 +125,11 @@ QGraphicsMozView::requestGLContext(bool& hasContext, QSize& viewPortSize)
     viewPortSize = d->mGLSurfaceSize;
 }
 
+void QGraphicsMozView::drawUnderlay()
+{
+    // Do nothing
+}
+
 /*! \reimp
 */
 QSizeF QGraphicsMozView::sizeHint(Qt::SizeHint which, const QSizeF& constraint) const

--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -103,6 +103,11 @@ void QGraphicsMozViewPrivate::CompositorCreated()
     mViewIface->createGeckoGLContext();
 }
 
+void QGraphicsMozViewPrivate::DrawUnderlay()
+{
+    mViewIface->drawUnderlay();
+}
+
 void QGraphicsMozViewPrivate::UpdateScrollArea(unsigned int aWidth, unsigned int aHeight, float aPosX, float aPosY)
 {
     bool widthChanged = false;
@@ -471,8 +476,16 @@ void QGraphicsMozViewPrivate::ViewInitialized()
 
 void QGraphicsMozViewPrivate::SetBackgroundColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
+    QMutexLocker locker(&mBgColorMutex);
     mBgColor = QColor(r, g, b, a);
     mViewIface->bgColorChanged();
+}
+
+// Can be read for instance from gecko compositor thread.
+QColor QGraphicsMozViewPrivate::GetBackgroundColor() const
+{
+    QMutexLocker locker(&mBgColorMutex);
+    return mBgColor;
 }
 
 bool QGraphicsMozViewPrivate::Invalidate()

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -13,6 +13,7 @@
 #include <QTime>
 #include <QString>
 #include <QPointF>
+#include <QMutex>
 #include <QMap>
 #include <QSGSimpleTextureNode>
 #include "qmozscrolldecorator.h"
@@ -37,6 +38,8 @@ public:
     virtual bool RequestCurrentGLContext();
     virtual void ViewInitialized();
     virtual void SetBackgroundColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+    virtual QColor GetBackgroundColor() const;
+
     virtual bool Invalidate();
     virtual void CompositingFinished();
     virtual void OnLocationChanged(const char* aLocation, bool aCanGoBack, bool aCanGoForward);
@@ -71,6 +74,9 @@ public:
     virtual void SetIsFocused(bool aIsFocused);
     virtual void CompositorCreated();
 
+    // Called always from the compositor thread.
+    virtual void DrawUnderlay();
+
     void UpdateScrollArea(unsigned int aWidth, unsigned int aHeight, float aPosX, float aPosY);
     void TestFlickingMode(QTouchEvent *event);
     void HandleTouchEnd(bool& draggingChanged, bool& pinchingChanged);
@@ -98,6 +104,7 @@ public:
     mozilla::embedlite::EmbedLiteView* mView;
     bool mViewInitialized;
     QColor mBgColor;
+    mutable QMutex mBgColorMutex;
     QImage mTempBufferImage;
     QSGTexture* mTempTexture;
     bool mEnabled;

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -128,7 +128,8 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void recvMouseRelease(int posX, int posY); \
     void CompositingFinished(); \
     bool Invalidate(); \
-    void requestGLContext(bool& hasContext, QSize& viewPortSize);
+    void requestGLContext(bool& hasContext, QSize& viewPortSize); \
+    void drawUnderlay();
 
 #define Q_MOZ_VIEW_SIGNALS \
     void viewInitialized(); \

--- a/src/qmozview_templated_wrapper.h
+++ b/src/qmozview_templated_wrapper.h
@@ -21,6 +21,7 @@ public:
     virtual void forceViewActiveFocus() = 0;
     virtual void createGeckoGLContext() = 0;
     virtual void requestGLContext(bool& hasContext, QSize& viewPortSize) = 0;
+    virtual void drawUnderlay() = 0;
     // Signals
     virtual void viewInitialized() = 0;
     virtual void urlChanged() = 0;
@@ -173,6 +174,11 @@ public:
     {
         view.requestGLContext(hasContext, viewPortSize);
     }
+    void drawUnderlay()
+    {
+        view.drawUnderlay();
+    }
+
     void useQmlMouse(bool value)
     {
         Q_EMIT view.useQmlMouse(value);

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -130,6 +130,11 @@ void QuickMozView::requestGLContext(bool& hasContext, QSize& viewPortSize)
     viewPortSize = d->mGLSurfaceSize;
 }
 
+void QuickMozView::drawUnderlay()
+{
+    // Do nothing
+}
+
 void QuickMozView::updateGLContextInfo(QOpenGLContext* ctx)
 {
     d->mHasContext = ctx != nullptr && ctx->surface() != nullptr;


### PR DESCRIPTION
JB#28056

Add draw underlay implementation for the opengl web page. Background color of the web page is used as glClearColor.

See also:
https://github.com/nemomobile-packages/gecko-dev/pull/8
https://github.com/tmeshkova/gecko-dev/pull/50