### PR TITLE
Use screenrotation api for opengl webpage

### DIFF
--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -17,6 +17,7 @@
 #include "InputData.h"
 #include "mozilla/embedlite/EmbedLiteApp.h"
 #include "mozilla/gfx/Tools.h"
+#include "mozilla/WidgetUtils.h"
 #include "qmozembedlog.h"
 #include <sys/time.h>
 #include "mozilla/TimeStamp.h"
@@ -84,6 +85,8 @@ QGraphicsMozViewPrivate::QGraphicsMozViewPrivate(IMozQViewIface* aViewIface, QOb
     , mViewIsFocused(false)
     , mHasContext(false)
     , mGLSurfaceSize(0,0)
+    , mOrientation(Qt::PrimaryOrientation)
+    , mOrientationDirty(false)
     , mPressed(false)
     , mDragging(false)
     , mFlicking(false)
@@ -434,6 +437,25 @@ void QGraphicsMozViewPrivate::UpdateViewSize()
         mView->SetGLViewPortSize(mGLSurfaceSize.width(), mGLSurfaceSize.height());
     }
     mView->SetViewSize(mSize.width(), mSize.height());
+
+    if (mOrientationDirty) {
+        ScreenRotation rotation = ROTATION_0;
+        switch (mOrientation) {
+        case Qt::LandscapeOrientation:
+            rotation = mozilla::ROTATION_90;
+            break;
+        case Qt::InvertedLandscapeOrientation:
+            rotation = mozilla::ROTATION_270;
+            break;
+        case Qt::InvertedPortraitOrientation:
+            rotation = mozilla::ROTATION_180;
+            break;
+        default:
+            break;
+        }
+        mView->SetScreenRotation(rotation);
+        mOrientationDirty = false;
+    }
 }
 
 bool QGraphicsMozViewPrivate::RequestCurrentGLContext()

--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -303,7 +303,6 @@ void QGraphicsMozViewPrivate::addMessageListeners(const QStringList &messageName
 void QGraphicsMozViewPrivate::timerEvent(QTimerEvent *event)
 {
     Q_ASSERT(q);
-
     if (event->timerId() == mMovingTimerId) {
         qreal offsetY = mScrollableOffset.y();
         qreal offsetX = mScrollableOffset.x();
@@ -321,7 +320,11 @@ void QGraphicsMozViewPrivate::timerEvent(QTimerEvent *event)
 void QGraphicsMozViewPrivate::startMoveMonitor()
 {
     Q_ASSERT(q);
-
+    // Kill running move monitor.
+    if (mMovingTimerId > 0) {
+        q->killTimer(mMovingTimerId);;
+        mMovingTimerId = 0;
+    }
     mMovingTimerId = q->startTimer(MOZVIEW_FLICK_STOP_TIMEOUT);
     mFlicking = true;
 }

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -146,6 +146,8 @@ public:
     bool mViewIsFocused;
     bool mHasContext;
     QSize mGLSurfaceSize;
+    Qt::ScreenOrientation mOrientation;
+    bool mOrientationDirty;
     bool mPressed;
     bool mDragging;
     bool mFlicking;

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -32,9 +32,9 @@ class QOpenGLWebPage : public QObject
     Q_PROPERTY(qreal width READ width WRITE setWidth NOTIFY widthChanged FINAL)
     Q_PROPERTY(qreal height READ height WRITE setHeight NOTIFY heightChanged FINAL)
     Q_PROPERTY(QSizeF size READ size WRITE setSize NOTIFY sizeChanged FINAL)
-
     Q_PROPERTY(bool background READ background WRITE setBackground NOTIFY backgroundChanged FINAL)
     Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged FINAL)
+    Q_PROPERTY(QWindow *window READ window WRITE setWindow NOTIFY windowChanged FINAL)
 
     Q_MOZ_VIEW_PRORERTIES
 
@@ -70,6 +70,9 @@ public:
 
     bool loaded() const;
 
+    QWindow *window();
+    void setWindow(QWindow *window);
+
     virtual bool event(QEvent *event);
     virtual void geometryChanged(const QRectF & newGeometry, const QRectF & oldGeometry);
     virtual QVariant inputMethodQuery(Qt::InputMethodQuery property) const;
@@ -86,6 +89,8 @@ public Q_SLOTS:
     void forceActiveFocus();
     void setInputMethodHints(Qt::InputMethodHints hints);
 
+    void updateContentOrientation(Qt::ScreenOrientation orientation);
+
 Q_SIGNALS:
     void setIsActive(bool);
     void parentIdChanged();
@@ -98,6 +103,7 @@ Q_SIGNALS:
     void sizeChanged();
     void backgroundChanged();
     void loadedChanged();
+    void windowChanged();
     void requestGLContext();
 
     Q_MOZ_VIEW_SIGNALS
@@ -109,6 +115,8 @@ private Q_SLOTS:
     void createView();
 
 private:
+    void setSurfaceSize(const QSize &surfaceSize, Qt::ScreenOrientation orientation);
+
     QGraphicsMozViewPrivate* d;
     friend class QGraphicsMozViewPrivate;
 
@@ -118,6 +126,7 @@ private:
     bool mBackground;
     bool mLoaded;
     bool mCompleted;
+    QWindow *mWindow;
 };
 
 QML_DECLARE_TYPE(QOpenGLWebPage)


### PR DESCRIPTION
Rebased and updated.

See also PR:
https://github.com/nemomobile-packages/gecko-dev/pull/9
https://github.com/nemomobile-packages/gecko-dev/pull/10
https://github.com/tmeshkova/gecko-dev/pull/52

This PR contains also a small fix that kills running move monitor when monitor restarted.