### PR TITLE
Remove cyclic dependency between public and private part of MozView

### DIFF
--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -12,6 +12,7 @@
 #include <QSize>
 #include <QTime>
 #include <QString>
+#include <QPointer>
 #include <QPointF>
 #include <QMutex>
 #include <QMap>
@@ -99,7 +100,7 @@ public:
     void sendAsyncMessage(const QString& name, const QVariant& variant);
 
     IMozQViewIface* mViewIface;
-    QScopedPointer<QObject> q;
+    QPointer<QObject> q;
     QMozContext* mContext;
     mozilla::embedlite::EmbedLiteView* mView;
     bool mViewInitialized;


### PR DESCRIPTION
Currently 3 public view implementations (QuickMozView, QGraphicsView,
QOpenGLWebPage) use the same common private part,
QGraphicsMozViewPrivate. In all 3 cases the public view implementations
create an instance of QGrapicsMozViewPrivate in their constructors and
remove it in desctructor. At the same time a pointer to the public view
implementaton is storred in QGraphicsMozViewPrivate::q variable.
Unfortunately the QScopedPointer template class is used to manage the
pointer. As a result when public view is destroyed it calls delete on
it's private part, which in turn removes public view once again when
QScopedPointer goes out of scope. The public view implementation is
destroyed twice.

This patch replaces QScopedPointer with QPointer which should ensure
each public view type is only destroyed once.