### PR TITLE
Implementation DrawWindowOverlay 

### DIFF
--- a/src/qgraphicsmozview.cpp
+++ b/src/qgraphicsmozview.cpp
@@ -130,6 +130,11 @@ void QGraphicsMozView::drawUnderlay()
     // Do nothing
 }
 
+void QGraphicsMozView::drawOverlay(const QRect &rect) {
+    Q_UNUSED(rect);
+    // Do nothing;
+}
+
 /*! \reimp
 */
 QSizeF QGraphicsMozView::sizeHint(Qt::SizeHint which, const QSizeF& constraint) const

--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -111,6 +111,12 @@ void QGraphicsMozViewPrivate::DrawUnderlay()
     mViewIface->drawUnderlay();
 }
 
+void QGraphicsMozViewPrivate::DrawOverlay(const nsIntRect& aRect)
+{
+    QRect rect(aRect.x, aRect.y, aRect.width, aRect.height);
+    mViewIface->drawOverlay(rect);
+}
+
 void QGraphicsMozViewPrivate::UpdateScrollArea(unsigned int aWidth, unsigned int aHeight, float aPosX, float aPosY)
 {
     bool widthChanged = false;

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -76,6 +76,7 @@ public:
 
     // Called always from the compositor thread.
     virtual void DrawUnderlay();
+    virtual void DrawOverlay(const nsIntRect& aRect);
 
     void UpdateScrollArea(unsigned int aWidth, unsigned int aHeight, float aPosX, float aPosY);
     void TestFlickingMode(QTouchEvent *event);

--- a/src/qmozgrabresult.cpp
+++ b/src/qmozgrabresult.cpp
@@ -1,0 +1,208 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "qopenglwebpage.h"
+#include "qmozgrabresult.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QOpenGLFunctions_ES2>
+#include <QPointer>
+#include <QSharedPointer>
+#include <QWindow>
+
+// Handle web page grab readiness through event loop so that connection type to the ready signal doesn't matter.
+const QEvent::Type Event_WebPageGrab_Completed = static_cast<QEvent::Type>(QEvent::registerEventType());
+
+QImage gl_read_framebuffer(const QRect &rect) {
+    QSize size = rect.size();
+    int x = rect.x();
+    int y = rect.y();
+
+    while (glGetError());
+
+    QImage img(size, QImage::Format_RGB32);
+    GLint fmt = GL_BGRA_EXT;
+    glReadPixels(x, y, size.width(), size.height(), fmt, GL_UNSIGNED_BYTE, img.bits());
+    if (!glGetError())
+        return img.mirrored();
+
+    QImage rgbaImage(size, QImage::Format_RGBX8888);
+    glReadPixels(x, y, size.width(), size.height(), GL_RGBA, GL_UNSIGNED_BYTE, rgbaImage.bits());
+    return rgbaImage.mirrored();
+}
+
+class QMozGrabResultPrivate
+{
+public:
+    QMozGrabResultPrivate(QMozGrabResult *q)
+        : q_ptr(q)
+        , ready(false)
+    {
+    }
+
+    static QMozGrabResult *create(QOpenGLWebPage *webPage, const QSize &targetSize);
+
+    QMozGrabResult *q_ptr;
+    QPointer<QOpenGLWebPage> webPage;
+    QSize textureSize;
+    QImage image;
+    Qt::ScreenOrientation orientation;
+    bool ready;
+};
+
+QMozGrabResult::~QMozGrabResult()
+{
+    if (d_ptr) {
+        delete d_ptr;
+        d_ptr = 0;
+    }
+}
+
+/*!
+ * \qmlproperty variant QMozGrabResult::image
+ *
+ * This property holds the pixel results from a grab in the
+ * form of a QImage.
+ */
+QImage QMozGrabResult::image() const
+{
+    Q_D(const QMozGrabResult);
+    return d->image;
+}
+
+bool QMozGrabResult::isReady() const
+{
+    Q_D(const QMozGrabResult);
+    return d->ready;
+}
+
+bool QMozGrabResult::saveToFile(const QString &fileName)
+{
+    Q_D(QMozGrabResult);
+    return d->image.save(fileName);
+}
+
+bool QMozGrabResult::event(QEvent *e)
+{
+    Q_D(QMozGrabResult);
+    if (e->type() == Event_WebPageGrab_Completed) {
+        d->ready = true;
+        Q_EMIT ready();
+        return true;
+    }
+    return QObject::event(e);
+}
+
+void QMozGrabResult::captureImage(const QRect &rect)
+{
+    Q_D(QMozGrabResult);
+    int w = d->textureSize.width();
+    int h = d->textureSize.height();
+
+    if (d->orientation == Qt::LandscapeOrientation || d->orientation == Qt::InvertedLandscapeOrientation) {
+        qSwap<int>(w, h);
+    }
+
+    int x = d->orientation == Qt::LandscapeOrientation ? rect.width() - w : 0;
+    int y = (d->orientation == Qt::PortraitOrientation || d->orientation == Qt::LandscapeOrientation) ? rect.height() - h : 0;
+
+    QRect targetRect(x, y, w, h);
+    QImage image = gl_read_framebuffer(targetRect);
+    if (d->orientation != Qt::PortraitOrientation && d->orientation != Qt::PrimaryOrientation) {
+        QMatrix rotationMatrix;
+        switch (d->orientation) {
+        case Qt::LandscapeOrientation:
+            rotationMatrix.rotate(270);
+            break;
+        case Qt::InvertedLandscapeOrientation:
+            rotationMatrix.rotate(90);
+            break;
+        case Qt::InvertedPortraitOrientation:
+            rotationMatrix.rotate(180);
+        default:
+            break;
+        }
+        image = image.transformed(rotationMatrix);
+    }
+
+    d->image = image;
+    disconnect(d->webPage.data(), &QOpenGLWebPage::afterRendering, this, &QMozGrabResult::captureImage);
+    QCoreApplication::postEvent(this, new QEvent(Event_WebPageGrab_Completed));
+}
+
+QMozGrabResult::QMozGrabResult(QObject *parent)
+    : QObject(parent)
+    , d_ptr(new QMozGrabResultPrivate(this))
+{
+}
+
+QMozGrabResult *QMozGrabResultPrivate::create(QOpenGLWebPage *webPage, const QSize &targetSize)
+{
+    Q_ASSERT(webPage);
+
+    QSize size = targetSize;
+    if (size.isEmpty()) {
+        size = QSize(webPage->width(), webPage->height());
+    }
+
+    if (!size.isValid()) {
+        qWarning() << "OpenGLWebPage::grabToImage web page has invalid dimensions";
+        return 0;
+    }
+
+    if (!webPage->window()) {
+        qWarning() << "OpenGLWebPage::grabToImage web page is not attached to a window";
+        return 0;
+    }
+
+    if (!webPage->window()->isVisible()) {
+        qWarning() << "OpenGLWebPage::grabToImage web page's window is not visible";
+        return 0;
+    }
+    if (!webPage->completed()) {
+        qWarning() << "OpenGLWebPage::grabToImage web page is not yet completed. Implies that view is not created.";
+        return 0;
+    }
+
+    if (!webPage->active()) {
+        qWarning() << "OpenGLWebPage::grabToImage only active web page can be grabbed";
+        return 0;
+    }
+
+    QMozGrabResult *result = new QMozGrabResult();
+    QMozGrabResultPrivate *d = result->d_func();
+    d->textureSize = size;
+    d->webPage = webPage;
+    d->orientation = webPage->window()->contentOrientation();
+
+    return result;
+}
+
+/*!
+ * Grabs the web page into an in-memory image.
+ *
+ * The grab happens asynchronously and the signal QMozGrabResult::ready() is emitted
+ * when the grab has been completed.
+ *
+ * The \a targetSize can be used to specify the size of the target image. By default, the
+ * result will have the same size as the web page.
+ *
+ * \note This function copies surface from the GPU's memory into CPU's memory, which can
+ * be quite costly operation. Smaller the \a targetSize better the performance.
+ */
+QSharedPointer<QMozGrabResult> QOpenGLWebPage::grabToImage(const QSize &targetSize)
+{
+    QMozGrabResult *result = QMozGrabResultPrivate::create(this, targetSize);
+    if (!result) {
+        return QSharedPointer<QMozGrabResult>();
+    } else {
+        connect(this, &QOpenGLWebPage::afterRendering, result, &QMozGrabResult::captureImage, Qt::DirectConnection);
+        update();
+    }
+
+    return QSharedPointer<QMozGrabResult>(result);
+}
+

--- a/src/qmozgrabresult.h
+++ b/src/qmozgrabresult.h
@@ -1,0 +1,49 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef QMOZGRABRESULT_H
+#define QMOZGRABRESULT_H
+
+#include <QtCore/QObject>
+#include <QtCore/QSize>
+#include <QtGui/QImage>
+
+class QOpenGLWebPage;
+class QMozGrabResultPrivate;
+
+class QMozGrabResult : public QObject
+{
+    Q_OBJECT
+    Q_DECLARE_PRIVATE(QMozGrabResult)
+
+    Q_PROPERTY(QImage image READ image CONSTANT)
+public:
+    ~QMozGrabResult();
+
+    QImage image() const;
+    bool isReady() const;
+
+    Q_INVOKABLE bool saveToFile(const QString &fileName);
+
+protected:
+    bool event(QEvent *e);
+
+Q_SIGNALS:
+    void ready();
+
+private Q_SLOTS:
+    void captureImage(const QRect &rect);
+
+private:
+    QMozGrabResultPrivate *d_ptr;
+
+    friend class QOpenGLWebPage;
+
+    QMozGrabResult(QObject *parent = 0);
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -4,6 +4,7 @@
 #include <QVariant>
 #include <QColor>
 #include <QUrl>
+#include <QRect>
 #include <QRectF>
 #include <QSizeF>
 #include <QString>
@@ -129,7 +130,8 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void CompositingFinished(); \
     bool Invalidate(); \
     void requestGLContext(bool& hasContext, QSize& viewPortSize); \
-    void drawUnderlay();
+    void drawUnderlay(); \
+    void drawOverlay(const QRect &rect);
 
 #define Q_MOZ_VIEW_SIGNALS \
     void viewInitialized(); \

--- a/src/qmozview_templated_wrapper.h
+++ b/src/qmozview_templated_wrapper.h
@@ -9,6 +9,7 @@
 
 class QPoint;
 class QString;
+class QRect;
 class QMozReturnValue;
 class IMozQViewIface
 {
@@ -22,6 +23,8 @@ public:
     virtual void createGeckoGLContext() = 0;
     virtual void requestGLContext(bool& hasContext, QSize& viewPortSize) = 0;
     virtual void drawUnderlay() = 0;
+    virtual void drawOverlay(const QRect &rect) = 0;
+
     // Signals
     virtual void viewInitialized() = 0;
     virtual void urlChanged() = 0;
@@ -177,6 +180,11 @@ public:
     void drawUnderlay()
     {
         view.drawUnderlay();
+    }
+
+    void drawOverlay(const QRect &rect)
+    {
+        view.drawOverlay(rect);
     }
 
     void useQmlMouse(bool value)

--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -163,6 +163,32 @@ void QOpenGLWebPage::drawUnderlay()
     }
 }
 
+/*!
+    \fn void QOpenGLWebPage::afterRendering(const QRect &rect)
+
+    This signal is emitted after web content has been rendered, before swapbuffers
+    has been called.
+
+    This signal can be used to paint using raw GL on top of the web content, or to do
+    screen scraping of the current frame buffer.
+
+    The GL context used for rendering is bound at this point.
+
+    This signal is emitted from the gecko compositor thread, you must make sure that
+    the connection is direct (see Qt::ConnectionType).
+*/
+
+/*!
+    \fn void QOpenGLWebPage::drawOverlay(const QRect &rect)
+
+    Called always from gecko compositor thread. Current context
+    has been made as current by gecko compositor.
+*/
+void QOpenGLWebPage::drawOverlay(const QRect &rect)
+{
+    Q_EMIT afterRendering(rect);
+}
+
 void QOpenGLWebPage::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
 {
     LOGT("newGeometry size: [%g, %g] oldGeometry size: [%g,%g]", newGeometry.size().width(),

--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -388,6 +388,15 @@ bool QOpenGLWebPage::completed() const
     return mCompleted;
 }
 
+void QOpenGLWebPage::update()
+{
+    if (!d->mViewInitialized) {
+        return;
+    }
+
+    d->mView->ScheduleUpdate();
+}
+
 void QOpenGLWebPage::forceActiveFocus()
 {
     Q_ASSERT(d->mViewInitialized);

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -105,6 +105,7 @@ Q_SIGNALS:
     void loadedChanged();
     void windowChanged();
     void requestGLContext();
+    void afterRendering(const QRect &rect);
 
     Q_MOZ_VIEW_SIGNALS
 

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -19,6 +19,7 @@
 #include "qmozview_defined_wrapper.h"
 
 class QGraphicsMozViewPrivate;
+class QMozGrabResult;
 
 class QOpenGLWebPage : public QObject
 {
@@ -84,8 +85,11 @@ public:
     virtual void touchEvent(QTouchEvent*);
     virtual void timerEvent(QTimerEvent*);
 
+    QSharedPointer<QMozGrabResult> grabToImage(const QSize &targetSize = QSize());
+
 public Q_SLOTS:
     Q_MOZ_VIEW_PUBLIC_SLOTS
+    void update();
     void forceActiveFocus();
     void setInputMethodHints(Qt::InputMethodHints hints);
 

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -135,6 +135,12 @@ void QuickMozView::drawUnderlay()
     // Do nothing
 }
 
+void QuickMozView::drawOverlay(const QRect &rect)
+{
+    Q_UNUSED(rect);
+    // Do nothing;
+}
+
 void QuickMozView::updateGLContextInfo(QOpenGLContext* ctx)
 {
     d->mHasContext = ctx != nullptr && ctx->surface() != nullptr;

--- a/src/src.pro
+++ b/src/src.pro
@@ -17,6 +17,7 @@ isEmpty(VERSION) {
 }
 
 SOURCES += qmozcontext.cpp \
+           qmozgrabresult.cpp \
            qmozscrolldecorator.cpp \
            qmessagepump.cpp \
            EmbedQtKeyUtils.cpp \
@@ -25,6 +26,7 @@ SOURCES += qmozcontext.cpp \
            qopenglwebpage.cpp
 
 HEADERS += qmozcontext.h \
+           qmozgrabresult.h \
            qmozviewcreator.h \
            qmozscrolldecorator.h \
            qmessagepump.h \


### PR DESCRIPTION
Contains two commits.

First one adds drawOverlay and the 2nd commit adds QQuickItem::grabToImage like API for openglwebpage.

Requires:
https://github.com/nemomobile-packages/gecko-dev/pull/11 (nemo embedlite 31)
https://github.com/tmeshkova/gecko-dev/pull/54 (embedlite esr)
https://github.com/tmeshkova/gecko-dev/pull/56 (embedlite)