### PR TITLE
Fix use after free crash in thumbnail capturing code JB#28888

### DIFF
--- a/src/qmozgrabresult.cpp
+++ b/src/qmozgrabresult.cpp
@@ -195,14 +195,11 @@ QMozGrabResult *QMozGrabResultPrivate::create(QOpenGLWebPage *webPage, const QSi
  */
 QSharedPointer<QMozGrabResult> QOpenGLWebPage::grabToImage(const QSize &targetSize)
 {
-    QMozGrabResult *result = QMozGrabResultPrivate::create(this, targetSize);
-    if (!result) {
-        return QSharedPointer<QMozGrabResult>();
-    } else {
-        connect(this, &QOpenGLWebPage::afterRendering, result, &QMozGrabResult::captureImage, Qt::DirectConnection);
+    QSharedPointer<QMozGrabResult> result(QMozGrabResultPrivate::create(this, targetSize));
+    if (result) {
+        mGrabResultList.append(result.toWeakRef());
         update();
     }
-
-    return QSharedPointer<QMozGrabResult>(result);
+    return result;
 }
 

--- a/src/qmozgrabresult.h
+++ b/src/qmozgrabresult.h
@@ -33,15 +33,15 @@ protected:
 Q_SIGNALS:
     void ready();
 
-private Q_SLOTS:
-    void captureImage(const QRect &rect);
-
 private:
-    QMozGrabResultPrivate *d_ptr;
-
     friend class QOpenGLWebPage;
 
     QMozGrabResult(QObject *parent = 0);
+    void captureImage(const QRect &rect);
+
+    QMozGrabResultPrivate *d_ptr;
+
+    Q_DISABLE_COPY(QMozGrabResult)
 };
 
 QT_END_NAMESPACE

--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -16,6 +16,7 @@
 #include <QOpenGLFunctions_ES2>
 #include <QWindow>
 
+#include "qmozgrabresult.h"
 #include "qgraphicsmozview_p.h"
 #include "qmozscrolldecorator.h"
 
@@ -64,6 +65,7 @@ QOpenGLWebPage::~QOpenGLWebPage()
         d->mView->SetListener(NULL);
         d->mContext->GetApp()->DestroyView(d->mView);
     }
+    mGrabResultList.clear();
     delete d;
 }
 
@@ -186,6 +188,17 @@ void QOpenGLWebPage::drawUnderlay()
 */
 void QOpenGLWebPage::drawOverlay(const QRect &rect)
 {
+    QList<QWeakPointer<QMozGrabResult> >::const_iterator it = mGrabResultList.begin();
+    for (; it != mGrabResultList.end(); ++it) {
+        QSharedPointer<QMozGrabResult> result = it->toStrongRef();
+        if (result) {
+            result->captureImage(rect);
+        } else {
+            qWarning() << "QMozGrabResult freed before being realized!";
+        }
+    }
+    mGrabResultList.clear();
+
     Q_EMIT afterRendering(rect);
 }
 

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -132,6 +132,9 @@ private:
     bool mLoaded;
     bool mCompleted;
     QWindow *mWindow;
+    QList<QWeakPointer<QMozGrabResult> > mGrabResultList;
+
+    Q_DISABLE_COPY(QOpenGLWebPage)
 };
 
 QML_DECLARE_TYPE(QOpenGLWebPage)


### PR DESCRIPTION
The QMozGrabResult object is expected to be created from the main
application thread. Unfotunately the QMozGrabResult::captureImage is
currently directly connected to QOpenGLWebPage::afterRendering slot
which is invoked on Gecko's compositor thread. This means the object can
actually be in use when the UI thread removes it.

To fix the problem QOpenGLWebPage was extended to keep a list of weak
refs to QMozGrabResuls it was asked to handle. When
QOpenGLWebpage::drawOverlay is invoked, the code iterates over pending
grab results, tries to convert weak refs into strong ones and only
invokes the captureImage function when the conversion is successful.
If the UI thread removed the object before the capture process was
realized on the compostor thread the weak ref will be invalid and the
image capture process can be simply aborted. In case the UI thread tries
to remove QMozGrabResult while it's actually being processed the newly
aquired strong ref on the compositor thread will keep the object alve
until the capture process is finished.