### PR TITLE
[qtmozembed] Aynchronize access to QOpenGLWebPage::mGrabResultListLoc…

### DIFF
--- a/src/qmozgrabresult.cpp
+++ b/src/qmozgrabresult.cpp
@@ -129,7 +129,6 @@ void QMozGrabResult::captureImage(const QRect &rect)
     }
 
     d->image = image;
-    disconnect(d->webPage.data(), &QOpenGLWebPage::afterRendering, this, &QMozGrabResult::captureImage);
     QCoreApplication::postEvent(this, new QEvent(Event_WebPageGrab_Completed));
 }
 
@@ -197,6 +196,7 @@ QSharedPointer<QMozGrabResult> QOpenGLWebPage::grabToImage(const QSize &targetSi
 {
     QSharedPointer<QMozGrabResult> result(QMozGrabResultPrivate::create(this, targetSize));
     if (result) {
+        QMutexLocker lock(&mGrabResultListLock);
         mGrabResultList.append(result.toWeakRef());
         update();
     }

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -15,6 +15,7 @@
 #include <QKeyEvent>
 #include <QFocusEvent>
 #include <QTouchEvent>
+#include <QMutex>
 
 #include "qmozview_defined_wrapper.h"
 
@@ -131,6 +132,7 @@ private:
     bool mCompleted;
     QWindow *mWindow;
     QList<QWeakPointer<QMozGrabResult> > mGrabResultList;
+    QMutex mGrabResultListLock;
 
     Q_DISABLE_COPY(QOpenGLWebPage)
 };


### PR DESCRIPTION
…k JB#28888

Since the QOpenGLWebPage::mGrabResultListLock is accessed from two
different threads (UI, Compositor) we need to properly synchronize
access to it.

This patch also removed no longer needed disconnect call from
QMozGrabResult. We're no longer connecting anything to that slot so the
disconnect was basically a no-op.