### PR TITLE
[qtmozembed] Remove unused background property.

### DIFF
--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -39,7 +39,6 @@ QOpenGLWebPage::QOpenGLWebPage(QObject *parent)
   , mParentID(0)
   , mPrivateMode(false)
   , mActive(false)
-  , mBackground(false)
   , mLoaded(false)
   , mCompleted(false)
   , mWindow(0)
@@ -308,21 +307,6 @@ void QOpenGLWebPage::setSize(const QSizeF &size)
     }
 
     Q_EMIT sizeChanged();
-}
-
-bool QOpenGLWebPage::background() const
-{
-    return mBackground;
-}
-
-void QOpenGLWebPage::setBackground(bool background)
-{
-    if (mBackground == background) {
-        return;
-    }
-
-    mBackground = background;
-    Q_EMIT backgroundChanged();
 }
 
 bool QOpenGLWebPage::loaded() const

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -34,7 +34,6 @@ class QOpenGLWebPage : public QObject
     Q_PROPERTY(qreal width READ width WRITE setWidth NOTIFY widthChanged FINAL)
     Q_PROPERTY(qreal height READ height WRITE setHeight NOTIFY heightChanged FINAL)
     Q_PROPERTY(QSizeF size READ size WRITE setSize NOTIFY sizeChanged FINAL)
-    Q_PROPERTY(bool background READ background WRITE setBackground NOTIFY backgroundChanged FINAL)
     Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged FINAL)
     Q_PROPERTY(QWindow *window READ window WRITE setWindow NOTIFY windowChanged FINAL)
 
@@ -66,9 +65,6 @@ public:
 
     QSizeF size() const;
     void setSize(const QSizeF &size);
-
-    bool background() const;
-    void setBackground(bool background);
 
     bool loaded() const;
 
@@ -105,7 +101,6 @@ Q_SIGNALS:
     void widthChanged();
     void heightChanged();
     void sizeChanged();
-    void backgroundChanged();
     void loadedChanged();
     void windowChanged();
     void requestGLContext();
@@ -127,7 +122,6 @@ private:
     unsigned mParentID;
     bool mPrivateMode;
     bool mActive;
-    bool mBackground;
     bool mLoaded;
     bool mCompleted;
     QWindow *mWindow;


### PR DESCRIPTION
With multi window browser backgrounding is handled in the
browser content window.

JB#28880