### PR TITLE
[qtmozembed] Fix forceActiveFocus of openglwebpage

### DIFF
--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -405,9 +405,12 @@ void QOpenGLWebPage::update()
 
 void QOpenGLWebPage::forceActiveFocus()
 {
-    Q_ASSERT(d->mViewInitialized);
+    if (!d->mViewInitialized) {
+        return;
+    }
+
     setActive(true);
-    d->mView->SetIsFocused(true);
+    d->SetIsFocused(true);
 }
 
 void QOpenGLWebPage::setInputMethodHints(Qt::InputMethodHints hints)


### PR DESCRIPTION
Instead of assert return if view not initialized. The processViewInitialization
takes care of initial focus. SetIsFocused needs to go through
private class so that mViewIsFocused gets updated.