### PR TITLE
[qtmozembed] Add initialize method to complete instantiation. Contributes JB#27557

### DIFF
--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -49,12 +49,6 @@ QOpenGLWebPage::QOpenGLWebPage(QObject *parent)
     connect(this, SIGNAL(viewInitialized()), this, SLOT(processViewInitialization()));
     connect(this, SIGNAL(loadProgressChanged()), this, SLOT(updateLoaded()));
     connect(this, SIGNAL(loadingChanged()), this, SLOT(updateLoaded()));
-
-    if (!d->mContext->initialized()) {
-        connect(d->mContext, SIGNAL(onInitialized()), this, SLOT(createView()));
-    } else {
-        createView();
-    }
 }
 
 QOpenGLWebPage::~QOpenGLWebPage()
@@ -327,6 +321,21 @@ void QOpenGLWebPage::setWindow(QWindow *window)
 
     mWindow = window;
     Q_EMIT windowChanged();
+}
+
+
+/*!
+    \fn void QOpenGLWebPage::initialize()
+
+    Call initialize to complete web page creation.
+*/
+void QOpenGLWebPage::initialize()
+{
+    if (!d->mContext->initialized()) {
+        connect(d->mContext, SIGNAL(onInitialized()), this, SLOT(createView()));
+    } else {
+        createView();
+    }
 }
 
 bool QOpenGLWebPage::event(QEvent *event)

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -71,6 +71,8 @@ public:
     QWindow *window();
     void setWindow(QWindow *window);
 
+    void initialize();
+
     virtual bool event(QEvent *event);
     virtual void geometryChanged(const QRectF & newGeometry, const QRectF & oldGeometry);
     virtual QVariant inputMethodQuery(Qt::InputMethodQuery property) const;


### PR DESCRIPTION
The embedlite view is created when initialize() is called. This
needs to be called as a last step when instantiating a page.

When the page is wrapped inside a qml component we cannot
pass additional argument to the QQmlComponent::beginCreate.
Once state information is set for the instance, before calling
QQmlComponent::completeCreate complete initialization by
calling initialize().