### PR TITLE
[qtmozembed] Don't spam gecko with unnecessary size updates. JB#29317

### DIFF
--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -114,8 +114,10 @@ private Q_SLOTS:
     void processViewInitialization();
     void updateLoaded();
     void createView();
+    void updateSize();
 
 private:
+    void scheduleSizeUpdate();
     void setSurfaceSize(const QSize &surfaceSize, Qt::ScreenOrientation orientation);
 
     QGraphicsMozViewPrivate* d;
@@ -129,6 +131,7 @@ private:
     QWindow *mWindow;
     QList<QWeakPointer<QMozGrabResult> > mGrabResultList;
     QMutex mGrabResultListLock;
+    bool mSizeUpdateScheduled;
 
     Q_DISABLE_COPY(QOpenGLWebPage)
 };


### PR DESCRIPTION
Currently when the screen is rotated we end up sneding size updates to
the engine 3 times. Only the last size update is actuall correct.

For example on Jolla phone with screen size of 540x960 when the screen
is rotated from potrtrait mode to landscape.

1. QOpenGLWebPage::updateContentOrientation is called which in turn
   calls QOpenGLWebPage::setSurfaceSize(960x540, Landscape). Since the
   setSurfaceSize does not modify d->mSize, but it does call
   d->UpdateViewSize() will end up notifying gecko about view size
   change to 540x960 (old size still storred in d->mSize).
2. QML layer calls QOpenGLWebPage::setHeight(540), which in turn calls
   ::setSize(540x540). This invalid size is sent to the engine.
3. QML layer calls QOpenGLWebPage::setWidth(960), which calls
   ::setSize(960x540). This is the correct final size that is also
   sent to the engine.

This patch fixes the problem by:

1. Making sure QOpenGLWebPage::updateContentOrientation also modifies
   view size by calling ::setSize
2. Calling d->UpdateViewSize() from a queued slot connection. This way we
   can schedule view size update multiple times but in the end it'll be only
   called once.

With this patch in place rotating the screen updates embedlite view size only
once.