### PR TITLE
[qtmozembed] Expose EmbedLiteApp's task posting functionality. Contributes to JB#30162.

### DIFF
--- a/src/qmozcontext.cpp
+++ b/src/qmozcontext.cpp
@@ -265,6 +265,27 @@ QMozContext::GetInstance()
     return lsSingleton;
 }
 
+QMozContext::TaskHandle QMozContext::PostUITask(QMozContext::TaskCallback cb, void* data, int timeout)
+{
+    if (!d->mApp)
+        return nullptr;
+    return d->mApp->PostTask(cb, data, timeout);
+}
+
+QMozContext::TaskHandle QMozContext::PostCompositorTask(QMozContext::TaskCallback cb, void* data, int timeout)
+{
+    if (!d->mApp)
+        return nullptr;
+    return d->mApp->PostCompositorTask(cb, data, timeout);
+}
+
+void QMozContext::CancelTask(QMozContext::TaskHandle handle)
+{
+    if (!d->mApp)
+        return;
+    d->mApp->CancelTask(handle);
+}
+
 void QMozContext::runEmbedding(int aDelay)
 {
     if (!d->mEmbedStarted) {

--- a/src/qmozcontext.h
+++ b/src/qmozcontext.h
@@ -23,6 +23,9 @@ class QMozContext : public QObject
 {
     Q_OBJECT
 public:
+    typedef void (*TaskCallback)(void* data);
+    typedef void* TaskHandle;
+
     virtual ~QMozContext();
 
     mozilla::embedlite::EmbedLiteApp* GetApp();
@@ -32,6 +35,10 @@ public:
     Q_INVOKABLE bool isAccelerated() const;
 
     static QMozContext* GetInstance();
+
+    TaskHandle PostUITask(TaskCallback, void* data, int timeout = 0);
+    TaskHandle PostCompositorTask(TaskCallback, void* data, int timeout = 0);
+    void CancelTask(TaskHandle);
 
 Q_SIGNALS:
     void onInitialized();


### PR DESCRIPTION
This just exposes EmbedLiteApp::{PostTask|PostCompositorTask|CancelTask}
functions in QMozContext.