### PR TITLE
Revert "Clear compositing surface on active page destruction. JB#29995"

### DIFF
--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -56,9 +56,6 @@ QOpenGLWebPage::QOpenGLWebPage(QObject *parent)
 QOpenGLWebPage::~QOpenGLWebPage()
 {
     if (d->mView) {
-        if (mActive) {
-            d->mView->ClearContent(255, 255, 255, 0);
-        }
         d->mView->SetListener(NULL);
         d->mContext->GetApp()->DestroyView(d->mView);
     }


### PR DESCRIPTION
With the newly introduced EmbedLite compositor task posting fuctionality
the necessary surface clearing can be done easily by the application
itself. There is no need for the QOpenGLWebPage to take care of this
detail.

This reverts commit a74040242f4c4629a35756810a848ad2e2b70ce1.