### PR TITLE
Mark methods virtual to be able to override them in mock objects

### DIFF
--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -74,9 +74,9 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     Q_PROPERTY(qreal chromeGestureThreshold READ chromeGestureThreshold WRITE setChromeGestureThreshold NOTIFY chromeGestureThresholdChanged FINAL)
 
 #define Q_MOZ_VIEW_PUBLIC_METHODS \
-    QUrl url() const; \
+    virtual QUrl url() const; \
     void setUrl(const QUrl&); \
-    QString title() const; \
+    virtual QString title() const; \
     int loadProgress() const; \
     bool canGoBack() const; \
     bool canGoForward() const; \


### PR DESCRIPTION
In some unit tests we need to build custom environment
through using mock objects. In order to resolve methods
correctly those ones that need to be overriden should be
marked as virtual.