### PR TITLE
[qtmozembed] Disconnect inactive web page from draw overlay

### DIFF
--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -186,6 +186,14 @@ void QOpenGLWebPage::setActive(bool active)
         mActive = active;
         d->mView->SetIsActive(mActive);
         Q_EMIT activeChanged();
+
+        disconnect(mozWindow(), &QMozWindow::drawOverlay,
+                   this, &QOpenGLWebPage::onDrawOverlay);
+
+        if (mActive) {
+            connect(mozWindow(), &QMozWindow::drawOverlay,
+                    this, &QOpenGLWebPage::onDrawOverlay, Qt::DirectConnection);
+        }
     }
 }
 


### PR DESCRIPTION
We're not rendering inactive web pages. Thus, window level draw overlay should not trigger onDrawOverlay handler for inactive pages => let's disconnect always when activity changes and enable connection only if we're activating.
